### PR TITLE
Rename lib from 'underscore_48484645478084414891891' to 'ods_flutter'

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -3,7 +3,7 @@
 import 'package:english_words/english_words.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:underscore_48484645478084414891891/underscore_48484645478084414891891.dart';
+import 'package:ods_flutter/ods_flutter.dart';
 
 void main() {
   runApp(MyApp());

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -131,6 +131,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  ods_flutter:
+    dependency: "direct main"
+    description:
+      path: "../lib"
+      relative: true
+    source: path
+    version: "0.0.1"
   path:
     dependency: transitive
     description:
@@ -200,13 +207,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.16"
-  underscore_48484645478084414891891:
-    dependency: "direct main"
-    description:
-      path: "../lib"
-      relative: true
-    source: path
-    version: "0.0.3"
   vector_math:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -34,10 +34,10 @@ dependencies:
   english_words: ^4.0.0
   provider: ^6.0.0
   # Locally:
-  underscore_48484645478084414891891:
+  ods_flutter:
     path: ../lib
   # Remote
-  # underscore_48484645478084414891891: ^0.0.2
+  # ods_flutter: ^0.0.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/lib/lib/ods_flutter.dart
+++ b/lib/lib/ods_flutter.dart
@@ -1,4 +1,4 @@
-library underscore_48484645478084414891891;
+library ods_flutter;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';

--- a/lib/pubspec.yaml
+++ b/lib/pubspec.yaml
@@ -1,6 +1,6 @@
-name: underscore_48484645478084414891891
-description: A new Flutter package.
-version: 0.0.3
+name: ods_flutter
+description: ODS Flutter provides Orange Flutter components for Android and iOS to developers, and a demo application.
+version: 0.0.1
 homepage:
 
 environment:

--- a/lib/test/ods_flutter_test.dart
+++ b/lib/test/ods_flutter_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:underscore_48484645478084414891891/underscore_48484645478084414891891.dart';
+import 'package:ods_flutter/ods_flutter.dart';
 
 void main() {
   test('adds one to input values', () {


### PR DESCRIPTION
Linked to #47 

Our library was previously named "underscore_48484645478084414891891" while we were doing our first tests. It has now the real final name: "ods_flutter".

All the references have been changed so that the lib can be used by the demo app locally, and then remotely when it will be released/deployed on the store in 0.0.1 the first time.

Lib package now has a description.