### PR TITLE
Fix README.md issue template links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://orange-opensource.github.io/ods-flutter"><strong>Visit ODS Flutter</strong></a>
   <br>
   <br>
-  <a href="https://github.com/Orange-OpenSource/ods-flutter/issues/new?assignees=B3nz01d&labels=bug%2Ctriage&template=bug_report.yml&title=%5BBug%5D%3A+Bug+Summary">Report bug</a>
+  <a href="https://github.com/Orange-OpenSource/ods-flutter/issues/new?assignees=B3nz01d&labels=%F0%9F%90%9E%20bug%2C%F0%9F%94%8D%20triage&template=bug_report.yml&title=[Bug]%3A+Bug+Summary">Report bug</a>
   ·
-  <a href="https://github.com/Orange-OpenSource/ods-flutter/issues/new?assignees=B3nz01d&labels=feature%2Ctriage&template=feature_request.yml&title=%5Bfeature%5D%3A+">Request feature</a>
+  <a href="https://github.com/Orange-OpenSource/ods-flutter/issues/new?assignees=B3nz01d&labels=feature%2C%F0%9F%94%8D%20triage&template=feature_request.yml&title=[feature]%3A+%22">Request feature</a>
 </p>


### PR DESCRIPTION
Closes #57

Preview to check the links: https://github.com/Orange-OpenSource/ods-flutter/blob/main-jd-fix-README-links/README.md