### PR TITLE
Add GH tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  run:
+    name: Flutter tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: subosito/flutter-action@v1
+      - name: Run App tests
+        run: |
+          cd app
+          flutter test
+      - name: Run Lib tests
+        run: |
+          cd lib
+          flutter test

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -11,19 +11,15 @@ import 'package:ods_flutter_demo/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
     await tester.pumpWidget(const OdsApplication());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    expect(find.text('Guidelines'), findsNWidgets(2)); // 1 in the side menu and 1 in the title
+    expect(find.text('Modules'), findsOneWidget); // 1 in the side menu
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
+    await tester.tap(find.byIcon(Icons.check_box));
     await tester.pump();
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Guidelines'), findsOneWidget); // 1 in the side menu
+    expect(find.text('Modules'), findsNWidgets(2)); // 1 in the side menu and 1 in the title
   });
 }


### PR DESCRIPTION
The default test in `app` was failing: https://github.com/Orange-OpenSource/ods-flutter/actions/runs/4751016411?notification_referrer_id=NT_kwDOAQk5IrM2MjE1OTc0NjkzOjE3MzgxNjY2&notifications_query=is%3Aunread which is a good thing because it shows that this GH action is working.

After the fix in https://github.com/Orange-OpenSource/ods-flutter/pull/90/commits/c6ce09fd6b9fa42d6ea6a82b4199201e9ff4c10b, everything is green 🎉 