### PR TITLE
Fix 'Flutter Tests' README badge target

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Status
 
-[![Tests Status](https://img.shields.io/github/actions/workflow/status/Orange-OpenSource/ods-flutter/tests.yml?branch=main&label=Flutter%20Tests&logo=github)](https://github.com/Orange-OpenSource/ods-flutter/actions/workflows/tests.yml?query=branch%3Amain)
+[![Tests Status](https://img.shields.io/github/actions/workflow/status/Orange-OpenSource/ods-flutter/build.yml?branch=main&label=Flutter%20Build&logo=github)](https://github.com/Orange-OpenSource/ods-flutter/actions/workflows/build.yml?query=branch%3Amain)
 
 ## Content
 


### PR DESCRIPTION
### Description

This PR fixes the target link used to display the status of the latest main build/tests workflow.

The current one is broken because it references `test.yml` which has been removed recently.

![Screenshot 2023-06-21 at 09 20 36](https://github.com/Orange-OpenSource/ods-flutter/assets/17381666/2d0bf7d5-a7cd-43ad-aa70-2c7e583e9f76)

/cc @florentmaitre 