### PR TITLE
🐛 fix(web): add kIsWeb before Platform calls

### DIFF
--- a/app/lib/ui/about/detail/about_file_screen.dart
+++ b/app/lib/ui/about/detail/about_file_screen.dart
@@ -13,6 +13,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:markdown/markdown.dart' as md;
@@ -317,10 +318,14 @@ String convertToHtml(
   var result = "<html>";
   result += head;
 
-  if (Platform.isIOS) {
-    result += cssApple;
-  } else if (Platform.isAndroid) {
-    result += cssAndroid;
+  if (!kIsWeb) {
+    if (Platform.isIOS) {
+      result += cssApple;
+    } else {
+      if (Platform.isAndroid) {
+        result += cssAndroid;
+      }
+    }
   }
 
   result += "</head>";

--- a/app/lib/ui/components/textfields/textfield.dart
+++ b/app/lib/ui/components/textfields/textfield.dart
@@ -13,6 +13,7 @@
 import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/ods_flutter_app_localizations.dart';
 import 'package:ods_flutter/components/chips/ods_choice_chips.dart';
@@ -130,7 +131,7 @@ class _BodyState extends State<_Body> {
     ///Keyboard action
     switch (customizationState?.selectedKeyboardAction) {
       case KeyboardActionEnum.none:
-        if (Platform.isAndroid) {
+        if (kIsWeb || Platform.isAndroid) {
           keyboardAction = TextInputAction.none;
         } else if (Platform.isIOS) {
           keyboardAction = TextInputAction.unspecified;
@@ -152,7 +153,7 @@ class _BodyState extends State<_Body> {
         keyboardAction = TextInputAction.send;
         break;
       case KeyboardActionEnum.previous:
-        if (Platform.isAndroid) {
+        if (kIsWeb || Platform.isAndroid) {
           keyboardAction = TextInputAction.previous;
         }
         break;

--- a/app/lib/ui/components/textfields/textfield_password.dart
+++ b/app/lib/ui/components/textfields/textfield_password.dart
@@ -13,6 +13,7 @@
 import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/ods_flutter_app_localizations.dart';
 import 'package:ods_flutter/components/chips/ods_choice_chips.dart';
@@ -129,7 +130,7 @@ class _BodyState extends State<_Body> {
     ///Keyboard action
     switch (customizationState?.selectedKeyboardAction) {
       case KeyboardActionEnum.none:
-        if (Platform.isAndroid) {
+        if (kIsWeb || Platform.isAndroid) {
           keyboardAction = TextInputAction.none;
         } else if (Platform.isIOS) {
           keyboardAction = TextInputAction.unspecified;
@@ -151,7 +152,7 @@ class _BodyState extends State<_Body> {
         keyboardAction = TextInputAction.send;
         break;
       case KeyboardActionEnum.previous:
-        if (Platform.isAndroid) {
+        if (!kIsWeb && Platform.isAndroid) {
           keyboardAction = TextInputAction.previous;
         }
         break;

--- a/app/lib/ui/guidelines/typography/guideline_typography_screen.dart
+++ b/app/lib/ui/guidelines/typography/guideline_typography_screen.dart
@@ -12,6 +12,7 @@
 
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/ods_flutter_app_localizations.dart';
 import 'package:ods_flutter/components/divider/ods_divider.dart';
@@ -85,7 +86,7 @@ class GuidelineTypographyScreen extends StatelessWidget {
               padding: EdgeInsets.all(spacingM),
               child: Column(
                 children: [
-                  Platform.isAndroid
+                  kIsWeb || Platform.isAndroid
                       ? Text(
                           AppLocalizations.of(context)!
                               .guidelinesTypographyAndroidDescription,

--- a/library/lib/components/sheets_bottom/ods_sheets_bottom.dart
+++ b/library/lib/components/sheets_bottom/ods_sheets_bottom.dart
@@ -12,6 +12,7 @@
 
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:ods_flutter/guidelines/spacings.dart';
 
@@ -45,7 +46,7 @@ class _OdsSheetsBottomState extends State<OdsSheetsBottom> {
 
   @override
   Widget build(BuildContext context) {
-    double collapsedHeight = Platform.isAndroid ? 80 : 91;
+    double collapsedHeight = !kIsWeb && Platform.isAndroid ? 80 : 91;
 
     return Container(
       decoration: BoxDecoration(


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

None found

### Description

adding checks "kIsWeb" before calling `Plateform` methods

### Motivation & Context

`Plateform` is not supported by flutter web, so each time it is called, we must ensure that we are not in a web environment using `kIsWeb`

### Types of change

<!-- What types of changes does you code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Accessibility

- [ ] My change follows accessibility good practices

#### Design

- [ ] My change respects the design guidelines defined in [Orange Design System](https://system.design.orange.com/0c1af118d/p/8118d1-web)
- [ ] My change is compatible with responsive display

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] Manually test on simulators and on a physical device (Android & iOS, orientation change, dark/light mode)
- [ ] Code review
- [ ] Design review
- [ ] A11y review