### PR TITLE
refactor(widgets): stateful to stateless when possible

### DIFF
--- a/app/lib/ui/about/about_screen.dart
+++ b/app/lib/ui/about/about_screen.dart
@@ -22,7 +22,7 @@ class AboutScreen extends StatefulWidget {
   const AboutScreen({Key? key}) : super(key: key);
 
   @override
-  _AboutScreenState createState() => _AboutScreenState();
+  State<AboutScreen> createState() => _AboutScreenState();
 }
 
 class _AboutScreenState extends State<AboutScreen> {

--- a/app/lib/ui/components/app_bars/top/top_app_bar_large.dart
+++ b/app/lib/ui/components/app_bars/top/top_app_bar_large.dart
@@ -20,20 +20,9 @@ import 'package:ods_flutter_demo/ui/components/app_bars/top/top_app_bars_customi
 import 'package:ods_flutter_demo/ui/theme/theme_selector.dart';
 import 'package:ods_flutter_demo/ui/utilities/component_count_row.dart';
 
-class ComponentTopAppBarLarge extends StatefulWidget {
-  const ComponentTopAppBarLarge({super.key});
-  @override
-  State<ComponentTopAppBarLarge> createState() =>
-      _ComponentTopAppBarLargeState();
-}
-
-class _ComponentTopAppBarLargeState extends State<ComponentTopAppBarLarge> {
+class ComponentTopAppBarLarge extends StatelessWidget {
+  ComponentTopAppBarLarge({super.key});
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/app_bars/top/top_app_bars.dart
+++ b/app/lib/ui/components/app_bars/top/top_app_bars.dart
@@ -20,19 +20,9 @@ import 'package:ods_flutter_demo/ui/components/app_bars/top/top_app_bars_customi
 import 'package:ods_flutter_demo/ui/theme/theme_selector.dart';
 import 'package:ods_flutter_demo/ui/utilities/component_count_row.dart';
 
-class ComponentTopAppBars extends StatefulWidget {
-  const ComponentTopAppBars({super.key});
-  @override
-  State<ComponentTopAppBars> createState() => _ComponentTopAppBarsState();
-}
-
-class _ComponentTopAppBarsState extends State<ComponentTopAppBars> {
+class ComponentTopAppBars extends StatelessWidget {
+  ComponentTopAppBars({super.key});
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/buttons/button_contained.dart
+++ b/app/lib/ui/components/buttons/button_contained.dart
@@ -28,41 +28,35 @@ enum ButtonEmphasis {
   functional,
 }
 
-class ButtonsContained extends StatefulWidget {
+class ButtonsContained extends StatelessWidget {
+  const ButtonsContained({Key? key, required this.emphasis}) : super(key: key);
+
   final ButtonEmphasis emphasis;
-
-  ButtonsContained({Key? key, required this.emphasis}) : super(key: key);
-
-  @override
-  _ButtonsContainedState createState() => _ButtonsContainedState();
-}
-
-class _ButtonsContainedState extends State<ButtonsContained> {
-  _ButtonsContainedState();
 
   @override
   Widget build(BuildContext context) {
+    String getAppBarTitle() {
+      switch (emphasis) {
+        case ButtonEmphasis.highEmphasis:
+          return AppLocalizations.of(context)!.buttonsHighEmphasisVariantTitle;
+        case ButtonEmphasis.mediumEmphasis:
+          return AppLocalizations.of(context)!
+              .buttonsMediumEmphasisVariantTitle;
+        case ButtonEmphasis.functional:
+          return AppLocalizations.of(context)!.buttonsFunctionalVariantTitle;
+      }
+    }
+
     return ButtonCustomization(
       child: Scaffold(
         bottomSheet: OdsSheetsBottom(
-          sheetContent: _CustomizationContent(emphasis: widget.emphasis),
+          sheetContent: _CustomizationContent(emphasis: emphasis),
           title: AppLocalizations.of(context)!.componentCustomizeTitle,
         ),
         appBar: MainAppBar(getAppBarTitle()),
-        body: SafeArea(child: _Body(emphasis: widget.emphasis)),
+        body: SafeArea(child: _Body(emphasis: emphasis)),
       ),
     );
-  }
-
-  String getAppBarTitle() {
-    switch (widget.emphasis) {
-      case ButtonEmphasis.highEmphasis:
-        return AppLocalizations.of(context)!.buttonsHighEmphasisVariantTitle;
-      case ButtonEmphasis.mediumEmphasis:
-        return AppLocalizations.of(context)!.buttonsMediumEmphasisVariantTitle;
-      case ButtonEmphasis.functional:
-        return AppLocalizations.of(context)!.buttonsFunctionalVariantTitle;
-    }
   }
 }
 
@@ -117,11 +111,6 @@ class _CustomizationContent extends StatefulWidget {
 
 class _CustomizationContentState extends State<_CustomizationContent> {
   _CustomizationContentState();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/buttons/button_outlined.dart
+++ b/app/lib/ui/components/buttons/button_outlined.dart
@@ -20,20 +20,10 @@ import 'package:ods_flutter/guidelines/spacings.dart';
 import 'package:ods_flutter_demo/ui/components/buttons/button_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ButtonsOutlined extends StatefulWidget {
-  const ButtonsOutlined({super.key});
+class ButtonsOutlined extends StatelessWidget {
+  ButtonsOutlined({super.key});
 
-  @override
-  State<ButtonsOutlined> createState() => _ButtonsOutlinedState();
-}
-
-class _ButtonsOutlinedState extends State<ButtonsOutlined> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/buttons/button_text.dart
+++ b/app/lib/ui/components/buttons/button_text.dart
@@ -22,20 +22,10 @@ import 'package:ods_flutter_demo/ui/components/buttons/button_customization.dart
 import 'package:ods_flutter_demo/ui/components/buttons/button_enum.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ButtonsText extends StatefulWidget {
-  const ButtonsText({super.key});
+class ButtonsText extends StatelessWidget {
+  ButtonsText({super.key});
 
-  @override
-  State<ButtonsText> createState() => _ButtonsTextState();
-}
-
-class _ButtonsTextState extends State<ButtonsText> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -94,11 +84,6 @@ class _CustomizationContent extends StatefulWidget {
 
 class _CustomizationContentState extends State<_CustomizationContent> {
   _CustomizationContentState();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/buttons/buttons_icon/button_icon.dart
+++ b/app/lib/ui/components/buttons/buttons_icon/button_icon.dart
@@ -21,20 +21,10 @@ import 'package:ods_flutter_demo/ui/components/buttons/buttons_icon/button_icon_
 import 'package:ods_flutter_demo/ui/components/buttons/buttons_icon/button_icon_enum.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ButtonsIcons extends StatefulWidget {
-  const ButtonsIcons({super.key});
+class ButtonsIcons extends StatelessWidget {
+  ButtonsIcons({super.key});
 
-  @override
-  State<ButtonsIcons> createState() => _ButtonsIconsState();
-}
-
-class _ButtonsIconsState extends State<ButtonsIcons> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -125,11 +115,6 @@ class _CustomizationContent extends StatefulWidget {
 
 class _CustomizationContentState extends State<_CustomizationContent> {
   _CustomizationContentState();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/buttons/segmented/segmented_button.dart
+++ b/app/lib/ui/components/buttons/segmented/segmented_button.dart
@@ -24,20 +24,10 @@ import 'package:ods_flutter_demo/ui/utilities/component_count_row.dart';
 
 enum Foods { ham, milk, figs, eggs, oil }
 
-class SegmentedButtons extends StatefulWidget {
-  const SegmentedButtons({super.key});
+class SegmentedButtons extends StatelessWidget {
+  SegmentedButtons({super.key});
 
-  @override
-  State<SegmentedButtons> createState() => _SegmentedButtonsState();
-}
-
-class _SegmentedButtonsState extends State<SegmentedButtons> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/cards/card_horizontal.dart
+++ b/app/lib/ui/components/cards/card_horizontal.dart
@@ -27,20 +27,10 @@ import 'package:ods_flutter_demo/ui/components/cards/card_enum.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 import 'package:ods_flutter_demo/ui/utilities/component_count_row.dart';
 
-class CardHorizontal extends StatefulWidget {
-  const CardHorizontal({super.key});
+class CardHorizontal extends StatelessWidget {
+  CardHorizontal({super.key});
 
-  @override
-  State<CardHorizontal> createState() => _CardHorizontalState();
-}
-
-class _CardHorizontalState extends State<CardHorizontal> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/cards/card_small.dart
+++ b/app/lib/ui/components/cards/card_small.dart
@@ -23,20 +23,10 @@ import 'package:ods_flutter_demo/main.dart';
 import 'package:ods_flutter_demo/ui/components/cards/card_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class CardSmall extends StatefulWidget {
-  const CardSmall({super.key});
+class CardSmall extends StatelessWidget {
+  CardSmall({super.key});
 
-  @override
-  State<CardSmall> createState() => _CardSmallState();
-}
-
-class _CardSmallState extends State<CardSmall> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/cards/card_vertical_header_first.dart
+++ b/app/lib/ui/components/cards/card_vertical_header_first.dart
@@ -25,21 +25,10 @@ import 'package:ods_flutter_demo/ui/components/cards/card_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 import 'package:ods_flutter_demo/ui/utilities/component_count_row.dart';
 
-class CardVerticalHeaderFirst extends StatefulWidget {
-  const CardVerticalHeaderFirst({super.key});
+class CardVerticalHeaderFirst extends StatelessWidget {
+  CardVerticalHeaderFirst({super.key});
 
-  @override
-  State<CardVerticalHeaderFirst> createState() =>
-      _CardVerticalHeaderFirstState();
-}
-
-class _CardVerticalHeaderFirstState extends State<CardVerticalHeaderFirst> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -107,8 +96,8 @@ class _Body extends StatelessWidget {
               : null,
           title: recipe.title,
           subtitle:
-              customizationState?.hasSubtitle == true ? recipe.subtitle : null,
-          text: customizationState?.hasText == true ? recipe.description : null,
+              customizationState.hasSubtitle == true ? recipe.subtitle : null,
+          text: customizationState.hasText == true ? recipe.description : null,
           image: OdsCardImage(
             imageProvider: NetworkImage(recipe.url),
             contentDescription: '', //Optional
@@ -117,22 +106,14 @@ class _Body extends StatelessWidget {
           ),
           firstButton: firstButton,
           secondButton: secondButton,
-          onClick: customizationState!.clickable ? () {} : null,
+          onClick: customizationState.clickable ? () {} : null,
         ),
       ),
     );
   }
 }
 
-class _CustomizationContent extends StatefulWidget {
-  @override
-  State<_CustomizationContent> createState() => _CustomizationContentState();
-}
-
-class _CustomizationContentState extends State<_CustomizationContent> {
-  int selectedIndex = 0;
-  bool isFiltered = true;
-
+class _CustomizationContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final CardCustomizationState? customizationState =

--- a/app/lib/ui/components/cards/card_vertical_image_first.dart
+++ b/app/lib/ui/components/cards/card_vertical_image_first.dart
@@ -25,20 +25,10 @@ import 'package:ods_flutter_demo/ui/components/cards/card_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 import 'package:ods_flutter_demo/ui/utilities/component_count_row.dart';
 
-class CardVerticalImageFirst extends StatefulWidget {
-  const CardVerticalImageFirst({super.key});
+class CardVerticalImageFirst extends StatelessWidget {
+  CardVerticalImageFirst({super.key});
 
-  @override
-  State<CardVerticalImageFirst> createState() => _CardVerticalImageFirstState();
-}
-
-class _CardVerticalImageFirstState extends State<CardVerticalImageFirst> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -122,15 +112,7 @@ class _Body extends StatelessWidget {
   }
 }
 
-class _CustomizationContent extends StatefulWidget {
-  @override
-  State<_CustomizationContent> createState() => _CustomizationContentState();
-}
-
-class _CustomizationContentState extends State<_CustomizationContent> {
-  int selectedIndex = 0;
-  bool isFiltered = true;
-
+class _CustomizationContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final CardCustomizationState? customizationState =

--- a/app/lib/ui/components/checkboxes/checkboxes.dart
+++ b/app/lib/ui/components/checkboxes/checkboxes.dart
@@ -20,20 +20,10 @@ import 'package:ods_flutter_demo/main.dart';
 import 'package:ods_flutter_demo/ui/components/checkboxes/checkboxes_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ComponentCheckboxes extends StatefulWidget {
-  const ComponentCheckboxes({super.key});
+class ComponentCheckboxes extends StatelessWidget {
+  ComponentCheckboxes({super.key});
 
-  @override
-  State<ComponentCheckboxes> createState() => _ComponentCheckboxesState();
-}
-
-class _ComponentCheckboxesState extends State<ComponentCheckboxes> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/chips/chips_action.dart
+++ b/app/lib/ui/components/chips/chips_action.dart
@@ -22,19 +22,9 @@ import 'package:ods_flutter_demo/main.dart';
 import 'package:ods_flutter_demo/ui/components/chips/chips_customization.dart';
 import 'package:ods_flutter_demo/ui/theme/theme_selector.dart';
 
-class ComponentChipsAction extends StatefulWidget {
-  const ComponentChipsAction({super.key});
-  @override
-  State<ComponentChipsAction> createState() => _ComponentChipsActionState();
-}
-
-class _ComponentChipsActionState extends State<ComponentChipsAction> {
+class ComponentChipsAction extends StatelessWidget {
+  ComponentChipsAction({super.key});
   bool isFiltered = true;
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/chips/chips_choice.dart
+++ b/app/lib/ui/components/chips/chips_choice.dart
@@ -23,19 +23,8 @@ import 'package:ods_flutter_demo/ui/components/chips/chips_customization.dart';
 import 'package:ods_flutter_demo/ui/components/chips/chips_enum.dart';
 import 'package:ods_flutter_demo/ui/theme/theme_selector.dart';
 
-class ComponentChipsChoice extends StatefulWidget {
+class ComponentChipsChoice extends StatelessWidget {
   const ComponentChipsChoice({super.key});
-  @override
-  State<ComponentChipsChoice> createState() => _ComponentChipsChoiceState();
-}
-
-class _ComponentChipsChoiceState extends State<ComponentChipsChoice> {
-  bool isFiltered = true;
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/chips/chips_filter.dart
+++ b/app/lib/ui/components/chips/chips_filter.dart
@@ -24,19 +24,8 @@ import 'package:ods_flutter_demo/ui/components/chips/chips_customization.dart';
 import 'package:ods_flutter_demo/ui/components/chips/chips_enum.dart';
 import 'package:ods_flutter_demo/ui/theme/theme_selector.dart';
 
-class ComponentChipsFilter extends StatefulWidget {
+class ComponentChipsFilter extends StatelessWidget {
   const ComponentChipsFilter({super.key});
-  @override
-  State<ComponentChipsFilter> createState() => _ComponentChipsFilterState();
-}
-
-class _ComponentChipsFilterState extends State<ComponentChipsFilter> {
-  bool isFiltered = true;
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/chips/chips_input.dart
+++ b/app/lib/ui/components/chips/chips_input.dart
@@ -24,19 +24,8 @@ import 'package:ods_flutter_demo/ui/components/chips/chips_customization.dart';
 import 'package:ods_flutter_demo/ui/components/chips/chips_enum.dart';
 import 'package:ods_flutter_demo/ui/theme/theme_selector.dart';
 
-class ComponentChipsInput extends StatefulWidget {
+class ComponentChipsInput extends StatelessWidget {
   const ComponentChipsInput({super.key});
-  @override
-  State<ComponentChipsInput> createState() => _ComponentChipsInputState();
-}
-
-class _ComponentChipsInputState extends State<ComponentChipsInput> {
-  bool isFiltered = true;
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -56,15 +45,7 @@ class _ComponentChipsInputState extends State<ComponentChipsInput> {
   }
 }
 
-class _Body extends StatefulWidget {
-  @override
-  _BodyState createState() => _BodyState();
-}
-
-class _BodyState extends State<_Body> {
-  int selectedIndex = 0;
-  bool isFiltered = true;
-
+class _Body extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ChipsCustomizationState? customizationState =
@@ -157,7 +138,7 @@ class _CustomizationContentState extends State<_CustomizationContent> {
                       onClick: (selected) {
                         setState(() {
                           selectedIndex = index;
-                          isFiltered = selected!;
+                          isFiltered = selected;
                           customizationState?.selectedElement =
                               customizationState.elements[index];
                         });

--- a/app/lib/ui/components/components_screen.dart
+++ b/app/lib/ui/components/components_screen.dart
@@ -18,16 +18,11 @@ import 'package:ods_flutter_demo/ui/components/component_detail_screen.dart';
 import 'package:ods_flutter_demo/ui/components/component_entities.dart';
 import 'package:ods_flutter_demo/ui/utilities/display_image.dart';
 
-class ComponentsScreen extends StatefulWidget {
+class ComponentsScreen extends StatelessWidget {
   final List<Component> odsComponents;
 
   ComponentsScreen({required this.odsComponents});
 
-  @override
-  State<ComponentsScreen> createState() => _ComponentsScreenState();
-}
-
-class _ComponentsScreenState extends State<ComponentsScreen> {
   @override
   Widget build(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
@@ -55,7 +50,7 @@ class _ComponentsScreenState extends State<ComponentsScreen> {
         child: GridView.count(
           crossAxisCount: crossAxisCount,
           childAspectRatio: childAspectRatio,
-          children: widget.odsComponents.map(
+          children: odsComponents.map(
             (component) {
               return Column(
                 children: [

--- a/app/lib/ui/components/dialogs/dialogs.dart
+++ b/app/lib/ui/components/dialogs/dialogs.dart
@@ -45,12 +45,7 @@ class ComponentDialogs extends StatelessWidget {
   }
 }
 
-class _Body extends StatefulWidget {
-  @override
-  _BodyState createState() => _BodyState();
-}
-
-class _BodyState extends State<_Body> {
+class _Body extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final DialogsCustomizationState? customizationState =
@@ -128,12 +123,7 @@ class _BodyState extends State<_Body> {
   }
 }
 
-class _CustomizationContent extends StatefulWidget {
-  @override
-  State<_CustomizationContent> createState() => _CustomizationContentState();
-}
-
-class _CustomizationContentState extends State<_CustomizationContent> {
+class _CustomizationContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final DialogsCustomizationState? customizationState =

--- a/app/lib/ui/components/floating_action_button/floating_action_button.dart
+++ b/app/lib/ui/components/floating_action_button/floating_action_button.dart
@@ -25,22 +25,10 @@ import 'package:ods_flutter_demo/ui/components/floating_action_button/floating_a
 import 'package:ods_flutter_demo/ui/components/floating_action_button/floating_action_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ComponentFloatingActionButton extends StatefulWidget {
-  const ComponentFloatingActionButton({super.key});
+class ComponentFloatingActionButton extends StatelessWidget {
+  ComponentFloatingActionButton({super.key});
 
-  @override
-  State<ComponentFloatingActionButton> createState() =>
-      _ComponentFloatingActionButtonState();
-}
-
-class _ComponentFloatingActionButtonState
-    extends State<ComponentFloatingActionButton> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -155,7 +143,7 @@ class _CustomizationContentState extends State<_CustomizationContent> {
                       onClick: (selected) {
                         setState(() {
                           selectedIndex = index;
-                          isFiltered = selected!;
+                          isFiltered = selected;
                           customizationState?.selectedElement =
                               customizationState.elements[index];
                         });

--- a/app/lib/ui/components/list_item/list_checkbox.dart
+++ b/app/lib/ui/components/list_item/list_checkbox.dart
@@ -19,21 +19,10 @@ import 'package:ods_flutter_demo/main.dart';
 import 'package:ods_flutter_demo/ui/components/checkboxes/checkboxes_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ComponentCheckboxesList extends StatefulWidget {
-  const ComponentCheckboxesList({super.key});
+class ComponentCheckboxesList extends StatelessWidget {
+  ComponentCheckboxesList({super.key});
 
-  @override
-  State<ComponentCheckboxesList> createState() =>
-      _ComponentCheckboxesListState();
-}
-
-class _ComponentCheckboxesListState extends State<ComponentCheckboxesList> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/list_item/list_item.dart
+++ b/app/lib/ui/components/list_item/list_item.dart
@@ -24,21 +24,10 @@ import 'package:ods_flutter_demo/ui/components/list_item/list_leading_enum.dart'
 import 'package:ods_flutter_demo/ui/components/list_item/list_trailing_enum.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ComponentListsSelection extends StatefulWidget {
-  const ComponentListsSelection({super.key});
+class ComponentListsSelection extends StatelessWidget {
+  ComponentListsSelection({super.key});
 
-  @override
-  State<ComponentListsSelection> createState() =>
-      _ComponentListsSelectionState();
-}
-
-class _ComponentListsSelectionState extends State<ComponentListsSelection> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/list_item/list_radio_buttons.dart
+++ b/app/lib/ui/components/list_item/list_radio_buttons.dart
@@ -19,23 +19,10 @@ import 'package:ods_flutter_demo/main.dart';
 import 'package:ods_flutter_demo/ui/components/checkboxes/checkboxes_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ComponentRadioButtonsList extends StatefulWidget {
-  const ComponentRadioButtonsList({super.key});
+class ComponentRadioButtonsList extends StatelessWidget {
+  ComponentRadioButtonsList({super.key});
 
-  @override
-  State<ComponentRadioButtonsList> createState() =>
-      _ComponentRadioButtonsListState();
-}
-
-enum Options { option1, option2, option3 }
-
-class _ComponentRadioButtonsListState extends State<ComponentRadioButtonsList> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -52,6 +39,8 @@ class _ComponentRadioButtonsListState extends State<ComponentRadioButtonsList> {
     );
   }
 }
+
+enum Options { option1, option2, option3 }
 
 class _Body extends StatefulWidget {
   @override

--- a/app/lib/ui/components/list_item/list_switches.dart
+++ b/app/lib/ui/components/list_item/list_switches.dart
@@ -18,20 +18,10 @@ import 'package:ods_flutter_demo/main.dart';
 import 'package:ods_flutter_demo/ui/components/switches/switches_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ComponentSwitchesList extends StatefulWidget {
-  const ComponentSwitchesList({super.key});
+class ComponentSwitchesList extends StatelessWidget {
+  ComponentSwitchesList({super.key});
 
-  @override
-  State<ComponentSwitchesList> createState() => _ComponentSwitchesListState();
-}
-
-class _ComponentSwitchesListState extends State<ComponentSwitchesList> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -77,7 +67,7 @@ class __BodyState extends State<_Body> {
                   customizationState?.hasEnabled == true ? isEnabled : false,
               onCheckedChange: (value) {
                 setState(() {
-                  isChecked0 = value!;
+                  isChecked0 = value;
                 });
               },
             ),
@@ -89,7 +79,7 @@ class __BodyState extends State<_Body> {
                   customizationState?.hasEnabled == true ? isEnabled : false,
               onCheckedChange: (value) {
                 setState(() {
-                  isChecked1 = value!;
+                  isChecked1 = value;
                 });
               },
             ),
@@ -101,7 +91,7 @@ class __BodyState extends State<_Body> {
                   customizationState?.hasEnabled == true ? isEnabled : false,
               onCheckedChange: (value) {
                 setState(() {
-                  isChecked2 = value!;
+                  isChecked2 = value;
                 });
               },
             ),

--- a/app/lib/ui/components/menus/menu_dropdown.dart
+++ b/app/lib/ui/components/menus/menu_dropdown.dart
@@ -24,20 +24,10 @@ import 'package:ods_flutter_demo/main.dart';
 import 'package:ods_flutter_demo/ui/components/menus/menu_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ComponentMenuDropdown extends StatefulWidget {
-  const ComponentMenuDropdown({super.key});
+class ComponentMenuDropdown extends StatelessWidget {
+  ComponentMenuDropdown({super.key});
 
-  @override
-  State<ComponentMenuDropdown> createState() => _ComponentMenuDropdownState();
-}
-
-class _ComponentMenuDropdownState extends State<ComponentMenuDropdown> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -55,13 +45,8 @@ class _ComponentMenuDropdownState extends State<ComponentMenuDropdown> {
   }
 }
 
-class _Body extends StatefulWidget {
-  @override
-  __BodyState createState() => __BodyState();
-}
-
-class __BodyState extends State<_Body> {
-  var recipe =
+class _Body extends StatelessWidget {
+  final recipe =
       OdsApplication.recipes[Random().nextInt(OdsApplication.recipes.length)];
 
   @override

--- a/app/lib/ui/components/menus/menu_exposed_dropdown.dart
+++ b/app/lib/ui/components/menus/menu_exposed_dropdown.dart
@@ -21,20 +21,10 @@ import 'package:ods_flutter_demo/main.dart';
 import 'package:ods_flutter_demo/ui/components/menus/menu_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class MenuExposedDropdown extends StatefulWidget {
-  const MenuExposedDropdown({super.key});
+class MenuExposedDropdown extends StatelessWidget {
+  MenuExposedDropdown({super.key});
 
-  @override
-  State<MenuExposedDropdown> createState() => _MenuExposedDropdownState();
-}
-
-class _MenuExposedDropdownState extends State<MenuExposedDropdown> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/navigation_bar/navigation_bar.dart
+++ b/app/lib/ui/components/navigation_bar/navigation_bar.dart
@@ -21,20 +21,10 @@ import 'package:ods_flutter_demo/ui/components/navigation_bar/navigation_bar_cus
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 import 'package:ods_flutter_demo/ui/utilities/component_count_row.dart';
 
-class ComponentNavigationBar extends StatefulWidget {
-  const ComponentNavigationBar({Key? key}) : super(key: key);
+class ComponentNavigationBar extends StatelessWidget {
+  ComponentNavigationBar({Key? key}) : super(key: key);
 
-  @override
-  State<ComponentNavigationBar> createState() => _ComponentNavigationBarState();
-}
-
-class _ComponentNavigationBarState extends State<ComponentNavigationBar> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/navigation_rail/navigation_rail.dart
+++ b/app/lib/ui/components/navigation_rail/navigation_rail.dart
@@ -26,21 +26,10 @@ import 'package:ods_flutter_demo/ui/components/navigation_rail/navigation_rail_e
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 import 'package:ods_flutter_demo/ui/utilities/component_count_row.dart';
 
-class ComponentNavigationRail extends StatefulWidget {
-  const ComponentNavigationRail({Key? key}) : super(key: key);
+class ComponentNavigationRail extends StatelessWidget {
+  ComponentNavigationRail({Key? key}) : super(key: key);
 
-  @override
-  State<ComponentNavigationRail> createState() =>
-      _ComponentNavigationBarState();
-}
-
-class _ComponentNavigationBarState extends State<ComponentNavigationRail> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -251,7 +240,7 @@ class _CustomizationContentState extends State<_CustomizationContent> {
             scrollDirection: Axis.horizontal,
             child: Row(
               children: List<Widget>.generate(
-                customizationState!.elements.length,
+                customizationState.elements.length,
                 (int index) {
                   NavigationRailsEnum currentElement =
                       customizationState.elements[index];

--- a/app/lib/ui/components/progress/progress_circular.dart
+++ b/app/lib/ui/components/progress/progress_circular.dart
@@ -43,12 +43,7 @@ class ComponentProgressCircular extends StatelessWidget {
   }
 }
 
-class _Body extends StatefulWidget {
-  @override
-  _BodyState createState() => _BodyState();
-}
-
-class _BodyState extends State<_Body> {
+class _Body extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ProgressCustomizationState? customizationState =

--- a/app/lib/ui/components/progress/progress_linear.dart
+++ b/app/lib/ui/components/progress/progress_linear.dart
@@ -43,12 +43,7 @@ class ComponentProgressLinear extends StatelessWidget {
   }
 }
 
-class _Body extends StatefulWidget {
-  @override
-  _BodyState createState() => _BodyState();
-}
-
-class _BodyState extends State<_Body> {
+class _Body extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ProgressCustomizationState? customizationState =

--- a/app/lib/ui/components/radio_buttons/radio_buttons.dart
+++ b/app/lib/ui/components/radio_buttons/radio_buttons.dart
@@ -19,22 +19,10 @@ import 'package:ods_flutter_demo/main.dart';
 import 'package:ods_flutter_demo/ui/components/radio_buttons/radio_buttons_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ComponentRadioButtons extends StatefulWidget {
-  const ComponentRadioButtons({Key? key}) : super(key: key);
+class ComponentRadioButtons extends StatelessWidget {
+  ComponentRadioButtons({Key? key}) : super(key: key);
 
-  @override
-  State<ComponentRadioButtons> createState() => _ComponentRadioButtonsState();
-}
-
-enum Options { option1, option2 }
-
-class _ComponentRadioButtonsState extends State<ComponentRadioButtons> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -51,6 +39,8 @@ class _ComponentRadioButtonsState extends State<ComponentRadioButtons> {
     );
   }
 }
+
+enum Options { option1, option2 }
 
 class _Body extends StatefulWidget {
   @override

--- a/app/lib/ui/components/sheets_bottom/sheets_bottom.dart
+++ b/app/lib/ui/components/sheets_bottom/sheets_bottom.dart
@@ -23,17 +23,8 @@ import 'package:ods_flutter_demo/ui/components/sheets_bottom/sheets_bottom_custo
 import 'package:ods_flutter_demo/ui/components/sheets_bottom/sheets_bottom_enum.dart';
 import 'package:ods_flutter_demo/ui/theme/theme_selector.dart';
 
-class ComponentSheetsBottom extends StatefulWidget {
+class ComponentSheetsBottom extends StatelessWidget {
   const ComponentSheetsBottom({super.key});
-  @override
-  State<ComponentSheetsBottom> createState() => _ComponentSheetsBottomState();
-}
-
-class _ComponentSheetsBottomState extends State<ComponentSheetsBottom> {
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -95,7 +86,7 @@ class _BodyState extends State<_Body> {
                     setState(
                       () {
                         selectedIndex = index;
-                        isFiltered = selected!;
+                        isFiltered = selected;
                         customizationState.selectedElement =
                             customizationState.elements[index];
                       },
@@ -112,12 +103,7 @@ class _BodyState extends State<_Body> {
   }
 }
 
-class _CustomizationContent extends StatefulWidget {
-  @override
-  State<_CustomizationContent> createState() => _CustomizationContentState();
-}
-
-class _CustomizationContentState extends State<_CustomizationContent> {
+class _CustomizationContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final SheetsBottomCustomizationState? customizationState =

--- a/app/lib/ui/components/sliders/sliders.dart
+++ b/app/lib/ui/components/sliders/sliders.dart
@@ -41,13 +41,8 @@ class ComponentSliders extends StatelessWidget {
   }
 }
 
-class _Body extends StatefulWidget {
-  @override
-  _BodyState createState() => _BodyState();
-}
-
-class _BodyState extends State<_Body> {
-  double value = 20.0;
+class _Body extends StatelessWidget {
+  final value = 20.0;
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/snackbars/snackbars.dart
+++ b/app/lib/ui/components/snackbars/snackbars.dart
@@ -21,20 +21,10 @@ import 'package:ods_flutter_demo/main.dart';
 import 'package:ods_flutter_demo/ui/components/snackbars/snackbars_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ComponentSnackbars extends StatefulWidget {
-  const ComponentSnackbars({Key? key}) : super(key: key);
+class ComponentSnackbars extends StatelessWidget {
+  ComponentSnackbars({Key? key}) : super(key: key);
 
-  @override
-  State<ComponentSnackbars> createState() => _ComponentSnackbarsState();
-}
-
-class _ComponentSnackbarsState extends State<ComponentSnackbars> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/switches/switches.dart
+++ b/app/lib/ui/components/switches/switches.dart
@@ -18,20 +18,10 @@ import 'package:ods_flutter_demo/main.dart';
 import 'package:ods_flutter_demo/ui/components/switches/switches_customization.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ComponentSwitches extends StatefulWidget {
-  const ComponentSwitches({super.key});
+class ComponentSwitches extends StatelessWidget {
+  ComponentSwitches({super.key});
 
-  @override
-  State<ComponentSwitches> createState() => _ComponentSwitchesState();
-}
-
-class _ComponentSwitchesState extends State<ComponentSwitches> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -74,7 +64,7 @@ class __BodyState extends State<_Body> {
             enabled: customizationState?.hasEnabled == true ? isEnabled : false,
             onCheckedChange: (value) {
               setState(() {
-                isChecked = value!;
+                isChecked = value;
               });
             },
           ),

--- a/app/lib/ui/components/textfields/textfield.dart
+++ b/app/lib/ui/components/textfields/textfield.dart
@@ -38,11 +38,6 @@ class _ComponentTextFieldState extends State<ComponentTextField> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
 
   @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
     var themeNotifier = Provider.of<ModelTheme>(context);
     return TextFieldCustomization(
@@ -82,18 +77,11 @@ class _ComponentTextFieldState extends State<ComponentTextField> {
   }
 }
 
-class _Body extends StatefulWidget {
+class _Body extends StatelessWidget {
   _Body();
 
-  @override
-  State<_Body> createState() => _BodyState();
-}
-
-class _BodyState extends State<_Body> {
-  var recipe =
+  final recipe =
       OdsApplication.recipes[Random().nextInt(OdsApplication.recipes.length)];
-
-  _BodyState();
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/components/textfields/textfield_password.dart
+++ b/app/lib/ui/components/textfields/textfield_password.dart
@@ -40,11 +40,6 @@ class _ComponentTextFieldPasswordState
   final _scaffoldKey = GlobalKey<ScaffoldState>();
 
   @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
     var themeNotifier = Provider.of<ModelTheme>(context);
     return TextFieldCustomization(
@@ -85,13 +80,8 @@ class _ComponentTextFieldPasswordState
   }
 }
 
-class _Body extends StatefulWidget {
-  @override
-  State<_Body> createState() => _BodyState();
-}
-
-class _BodyState extends State<_Body> {
-  var recipe =
+class _Body extends StatelessWidget {
+  final recipe =
       OdsApplication.recipes[Random().nextInt(OdsApplication.recipes.length)];
 
   @override

--- a/app/lib/ui/guidelines/guidelines_screen.dart
+++ b/app/lib/ui/guidelines/guidelines_screen.dart
@@ -18,23 +18,18 @@ import 'package:ods_flutter/guidelines/spacings.dart';
 import 'package:ods_flutter_demo/ui/guidelines/guideline_detail_screen.dart';
 import 'package:ods_flutter_demo/ui/guidelines/guidelines_entities.dart';
 
-class GuidelinesScreen extends StatefulWidget {
+class GuidelinesScreen extends StatelessWidget {
   final List<Guideline> odsGuidelines;
 
   GuidelinesScreen({required this.odsGuidelines});
 
   @override
-  State<GuidelinesScreen> createState() => _GuidelinesScreenState();
-}
-
-class _GuidelinesScreenState extends State<GuidelinesScreen> {
-  @override
   Widget build(BuildContext context) {
     return SafeArea(
       child: ListView.builder(
-        itemCount: widget.odsGuidelines.length,
+        itemCount: odsGuidelines.length,
         itemBuilder: (context, index) {
-          var guideline = widget.odsGuidelines[index];
+          var guideline = odsGuidelines[index];
           return Padding(
             padding: const EdgeInsets.all(spacingS),
             child: Column(

--- a/app/lib/ui/modules/lists/module_lists_screen.dart
+++ b/app/lib/ui/modules/lists/module_lists_screen.dart
@@ -24,20 +24,10 @@ import 'package:ods_flutter_demo/ui/components/list_item/list_leading_enum.dart'
 import 'package:ods_flutter_demo/ui/components/list_item/list_trailing_enum.dart';
 import 'package:ods_flutter_demo/ui/main_app_bar.dart';
 
-class ModuleListsStandard extends StatefulWidget {
-  const ModuleListsStandard({super.key});
+class ModuleListsStandard extends StatelessWidget {
+  ModuleListsStandard({super.key});
 
-  @override
-  State<ModuleListsStandard> createState() => _ModuleListsStandardState();
-}
-
-class _ModuleListsStandardState extends State<ModuleListsStandard> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/ui/modules/modules_screen.dart
+++ b/app/lib/ui/modules/modules_screen.dart
@@ -17,23 +17,18 @@ import 'package:ods_flutter/components/card/ods_vertical_image_first_card.dart';
 import 'package:ods_flutter/guidelines/spacings.dart';
 import 'package:ods_flutter_demo/ui/modules/modules_entities.dart';
 
-class ModulesScreen extends StatefulWidget {
-  final List<Module> odsModules;
-
+class ModulesScreen extends StatelessWidget {
   ModulesScreen({required this.odsModules});
 
-  @override
-  State<ModulesScreen> createState() => _ModulesScreenState();
-}
+  final List<Module> odsModules;
 
-class _ModulesScreenState extends State<ModulesScreen> {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
       child: ListView.builder(
-        itemCount: widget.odsModules.length,
+        itemCount: odsModules.length,
         itemBuilder: (context, index) {
-          var module = widget.odsModules[index];
+          var module = odsModules[index];
           return Padding(
             padding: const EdgeInsets.all(spacingS),
             child: Column(

--- a/app/lib/ui/utilities/expandable_text.dart
+++ b/app/lib/ui/utilities/expandable_text.dart
@@ -19,7 +19,7 @@ class ExpandableTextWidget extends StatefulWidget {
   ExpandableTextWidget({required this.text, this.maxLines = 2});
 
   @override
-  _ExpandableTextWidgetState createState() => _ExpandableTextWidgetState();
+  State<ExpandableTextWidget> createState() => _ExpandableTextWidgetState();
 }
 
 class _ExpandableTextWidgetState extends State<ExpandableTextWidget> {

--- a/library/lib/components/button/ods_button.dart
+++ b/library/lib/components/button/ods_button.dart
@@ -42,7 +42,7 @@ enum OdsButtonStyle {
 ///
 /// Displays a customizable button with an optional icon and a title.
 /// The button can expand to full screen width if specified.
-class OdsButton extends StatefulWidget {
+class OdsButton extends StatelessWidget {
   /// Creates an ODS Button.
   ///
   /// * [text] - Text displayed in the button.
@@ -74,53 +74,64 @@ class OdsButton extends StatefulWidget {
   /// The background style.
   final OdsButtonStyle style;
 
-  @override
-  State<OdsButton> createState() => _OdsButtonState();
-}
-
-class _OdsButtonState extends State<OdsButton> {
   static const double minimumWidthButtonIcon = 108;
   static const double minimumHeightButtonIcon = 40;
 
-  OdsButtonColors getColorsForStyle(OdsButtonStyle? style) {
-    switch (style) {
-      case OdsButtonStyle.functionalPrimary:
-        return OdsButtonColors(
-            background: Theme.of(context).colorScheme.primary,
-            text: Theme.of(context).colorScheme.onPrimary,
-            icon: Theme.of(context).colorScheme.onPrimary,
-            textDisabled: grey500);
-      case OdsButtonStyle.functionalDefault:
-        return OdsButtonColors(
-            background: Theme.of(context).colorScheme.secondary,
-            text: Theme.of(context).colorScheme.onSecondary,
-            icon: Theme.of(context).colorScheme.onSecondary,
-            textDisabled: grey500);
-      case OdsButtonStyle.functionalPositive:
-        return OdsButtonColors(
-            background: positive200,
-            text: Theme.of(context).colorScheme.onSecondary,
-            icon: Theme.of(context).colorScheme.onSecondary,
-            textDisabled: grey500);
-      case OdsButtonStyle.functionalNegative:
-        return OdsButtonColors(
-            background: Theme.of(context).colorScheme.error,
-            text: Theme.of(context).colorScheme.onSecondary,
-            icon: Theme.of(context).colorScheme.onSecondary,
-            textDisabled: grey500);
-      default:
-        return OdsButtonColors(
-            background: Theme.of(context).colorScheme.primary,
-            text: black900,
-            textDisabled: grey500);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    final styleButtonColor = getColorsForStyle(widget.style);
+    OdsButtonColors getColorsForStyle(OdsButtonStyle? style) {
+      switch (style) {
+        case OdsButtonStyle.functionalPrimary:
+          return OdsButtonColors(
+              background: Theme.of(context).colorScheme.primary,
+              text: Theme.of(context).colorScheme.onPrimary,
+              icon: Theme.of(context).colorScheme.onPrimary,
+              textDisabled: grey500);
+        case OdsButtonStyle.functionalDefault:
+          return OdsButtonColors(
+              background: Theme.of(context).colorScheme.secondary,
+              text: Theme.of(context).colorScheme.onSecondary,
+              icon: Theme.of(context).colorScheme.onSecondary,
+              textDisabled: grey500);
+        case OdsButtonStyle.functionalPositive:
+          return OdsButtonColors(
+              background: positive200,
+              text: Theme.of(context).colorScheme.onSecondary,
+              icon: Theme.of(context).colorScheme.onSecondary,
+              textDisabled: grey500);
+        case OdsButtonStyle.functionalNegative:
+          return OdsButtonColors(
+              background: Theme.of(context).colorScheme.error,
+              text: Theme.of(context).colorScheme.onSecondary,
+              icon: Theme.of(context).colorScheme.onSecondary,
+              textDisabled: grey500);
+        default:
+          return OdsButtonColors(
+              background: Theme.of(context).colorScheme.primary,
+              text: black900,
+              textDisabled: grey500);
+      }
+    }
 
-    if (widget.icon != null && widget.fullWidth == false) {
+    ///Color Filter
+    Widget colorDefaultFilter() {
+      final styleButtonColor = getColorsForStyle(style);
+      return ColorFiltered(
+        colorFilter: ColorFilter.mode(styleButtonColor.icon!, BlendMode.srcIn),
+        child: icon,
+      );
+    }
+
+    Widget colorEnableFilter() {
+      return ColorFiltered(
+        colorFilter: const ColorFilter.mode(Colors.grey, BlendMode.srcIn),
+        child: icon,
+      );
+    }
+
+    final styleButtonColor = getColorsForStyle(style);
+
+    if (icon != null && fullWidth == false) {
       return SizedBox(
         child: FilledButton.icon(
           style: FilledButton.styleFrom(
@@ -130,17 +141,15 @@ class _OdsButtonState extends State<OdsButton> {
                 spacingM, spacingS, spacingL, spacingS),
             backgroundColor: styleButtonColor.background,
           ),
-          onPressed: widget.onClick,
+          onPressed: onClick,
           icon: ExcludeSemantics(
             excluding: true,
-            child: widget.onClick != null
-                ? colorDefaultFilter()
-                : _colorEnableFilter(),
+            child: onClick != null ? colorDefaultFilter() : colorEnableFilter(),
           ),
           label: Text(
-            widget.text,
+            text,
             style: TextStyle(
-              color: widget.onClick != null
+              color: onClick != null
                   ? styleButtonColor.text
                   : styleButtonColor.textDisabled,
             ),
@@ -149,21 +158,19 @@ class _OdsButtonState extends State<OdsButton> {
       );
     }
 
-    if (widget.icon != null && widget.fullWidth == true) {
+    if (icon != null && fullWidth == true) {
       return SizedBox(
         width: double.infinity,
         child: FilledButton.icon(
-          onPressed: widget.onClick,
+          onPressed: onClick,
           icon: ExcludeSemantics(
             excluding: true,
-            child: widget.onClick != null
-                ? colorDefaultFilter()
-                : _colorEnableFilter(),
+            child: onClick != null ? colorDefaultFilter() : colorEnableFilter(),
           ),
           label: Text(
-            widget.text,
+            text,
             style: TextStyle(
-              color: widget.onClick != null
+              color: onClick != null
                   ? styleButtonColor.text
                   : styleButtonColor.textDisabled,
             ),
@@ -174,17 +181,17 @@ class _OdsButtonState extends State<OdsButton> {
       );
     }
 
-    if (widget.fullWidth == true) {
+    if (fullWidth == true) {
       return SizedBox(
         width: double.infinity,
         child: FilledButton(
-          onPressed: widget.onClick,
+          onPressed: onClick,
           style: FilledButton.styleFrom(
               backgroundColor: styleButtonColor.background),
           child: Text(
-            widget.text,
+            text,
             style: TextStyle(
-              color: widget.onClick != null
+              color: onClick != null
                   ? styleButtonColor.text
                   : styleButtonColor.textDisabled,
             ),
@@ -194,33 +201,17 @@ class _OdsButtonState extends State<OdsButton> {
     }
 
     return FilledButton(
-      onPressed: widget.onClick,
+      onPressed: onClick,
       style:
           FilledButton.styleFrom(backgroundColor: styleButtonColor.background),
       child: Text(
-        widget.text,
+        text,
         style: TextStyle(
-          color: widget.onClick != null
+          color: onClick != null
               ? styleButtonColor.text
               : styleButtonColor.textDisabled,
         ),
       ),
-    );
-  }
-
-  ///Color Filter
-  Widget colorDefaultFilter() {
-    final styleButtonColor = getColorsForStyle(widget.style);
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(styleButtonColor.icon!, BlendMode.srcIn),
-      child: widget.icon,
-    );
-  }
-
-  Widget _colorEnableFilter() {
-    return ColorFiltered(
-      colorFilter: const ColorFilter.mode(Colors.grey, BlendMode.srcIn),
-      child: widget.icon,
     );
   }
 }

--- a/library/lib/components/button/ods_outlined_button.dart
+++ b/library/lib/components/button/ods_outlined_button.dart
@@ -16,7 +16,7 @@ import 'package:flutter/material.dart';
 ///
 /// Displays a customizable button with an optional icon and a title.
 /// The button can expand to full screen width if specified.
-class OdsOutlinedButton extends StatefulWidget {
+class OdsOutlinedButton extends StatelessWidget {
   /// Creates an ODS Outlined Button.
   ///
   /// * [text] - Text displayed in the button.
@@ -44,70 +44,61 @@ class OdsOutlinedButton extends StatefulWidget {
   final bool fullWidth;
 
   @override
-  State<OdsOutlinedButton> createState() => _OdsOutlinedButtonState();
-}
-
-class _OdsOutlinedButtonState extends State<OdsOutlinedButton> {
-  @override
   Widget build(BuildContext context) {
-    if (widget.icon != null && widget.fullWidth == false) {
-      return OutlinedButton.icon(
-        onPressed: widget.onClick,
-        icon: ExcludeSemantics(
-          excluding: true,
-          child: widget.onClick != null
-              ? colorDefaultFilter()
-              : _colorEnableFilter(),
-        ),
-        label: Text(widget.text),
+    ///Color Filter
+    Widget colorDefaultFilter() {
+      return ColorFiltered(
+        colorFilter: ColorFilter.mode(
+            Theme.of(context).colorScheme.secondary, BlendMode.srcIn),
+        child: icon,
       );
     }
 
-    if (widget.icon != null && widget.fullWidth == true) {
+    Widget colorEnableFilter() {
+      return ColorFiltered(
+        colorFilter: const ColorFilter.mode(Colors.grey, BlendMode.srcIn),
+        child: icon,
+      );
+    }
+
+    if (icon != null && fullWidth == false) {
+      return OutlinedButton.icon(
+        onPressed: onClick,
+        icon: ExcludeSemantics(
+          excluding: true,
+          child: onClick != null ? colorDefaultFilter() : colorEnableFilter(),
+        ),
+        label: Text(text),
+      );
+    }
+
+    if (icon != null && fullWidth == true) {
       return SizedBox(
         width: double.infinity,
         child: OutlinedButton.icon(
-          onPressed: widget.onClick,
+          onPressed: onClick,
           icon: ExcludeSemantics(
             excluding: true,
-            child: widget.onClick != null
-                ? colorDefaultFilter()
-                : _colorEnableFilter(),
+            child: onClick != null ? colorDefaultFilter() : colorEnableFilter(),
           ),
-          label: Text(widget.text),
+          label: Text(text),
         ),
       );
     }
 
-    if (widget.fullWidth == true) {
+    if (fullWidth == true) {
       return SizedBox(
         width: double.infinity,
         child: OutlinedButton(
-          onPressed: widget.onClick,
-          child: Text(widget.text),
+          onPressed: onClick,
+          child: Text(text),
         ),
       );
     }
 
     return OutlinedButton(
-      onPressed: widget.onClick,
-      child: Text(widget.text),
-    );
-  }
-
-  ///Color Filter
-  Widget colorDefaultFilter() {
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(
-          Theme.of(context).colorScheme.secondary, BlendMode.srcIn),
-      child: widget.icon,
-    );
-  }
-
-  Widget _colorEnableFilter() {
-    return ColorFiltered(
-      colorFilter: const ColorFilter.mode(Colors.grey, BlendMode.srcIn),
-      child: widget.icon,
+      onPressed: onClick,
+      child: Text(text),
     );
   }
 }

--- a/library/lib/components/button/ods_text_button.dart
+++ b/library/lib/components/button/ods_text_button.dart
@@ -40,7 +40,7 @@ enum OdsTextButtonStyle {
 ///
 /// Displays a customizable button with an optional icon and a title.
 /// The button can expand to full screen width if specified.
-class OdsTextButton extends StatefulWidget {
+class OdsTextButton extends StatelessWidget {
   /// Creates an ODS Text Button.
   ///
   /// * [text] - Text displayed in the button.
@@ -72,42 +72,53 @@ class OdsTextButton extends StatefulWidget {
   /// The background style.
   final OdsTextButtonStyle style;
 
-  @override
-  State<OdsTextButton> createState() => _OdsTextButtonState();
-}
-
-class _OdsTextButtonState extends State<OdsTextButton> {
   static const double minimumWidthButtonIcon = 108;
   static const double minimumHeightButtonIcon = 40;
 
-  OdsButtonColors getColorsForStyle(OdsTextButtonStyle? style) {
-    switch (style) {
-      case OdsTextButtonStyle.functionalPrimary:
-        return OdsButtonColors(
-            background: Colors.transparent,
-            text: Theme.of(context).colorScheme.primary,
-            icon: Theme.of(context).colorScheme.primary,
-            textDisabled: grey500);
-      case OdsTextButtonStyle.functionalDefault:
-        return OdsButtonColors(
-            background: Colors.transparent,
-            text: Theme.of(context).colorScheme.onSurface,
-            icon: Theme.of(context).colorScheme.secondary,
-            textDisabled: grey500);
-      default:
-        return OdsButtonColors(
-            background: Colors.transparent,
-            text: Theme.of(context).colorScheme.secondary,
-            icon: Theme.of(context).colorScheme.onSecondary,
-            textDisabled: grey500);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    final styleButtonColor = getColorsForStyle(widget.style);
+    OdsButtonColors getColorsForStyle(OdsTextButtonStyle? style) {
+      switch (style) {
+        case OdsTextButtonStyle.functionalPrimary:
+          return OdsButtonColors(
+              background: Colors.transparent,
+              text: Theme.of(context).colorScheme.primary,
+              icon: Theme.of(context).colorScheme.primary,
+              textDisabled: grey500);
+        case OdsTextButtonStyle.functionalDefault:
+          return OdsButtonColors(
+              background: Colors.transparent,
+              text: Theme.of(context).colorScheme.onSurface,
+              icon: Theme.of(context).colorScheme.secondary,
+              textDisabled: grey500);
+        default:
+          return OdsButtonColors(
+              background: Colors.transparent,
+              text: Theme.of(context).colorScheme.secondary,
+              icon: Theme.of(context).colorScheme.onSecondary,
+              textDisabled: grey500);
+      }
+    }
 
-    if (widget.icon != null && widget.fullWidth == false) {
+    ///Color Filter
+    Widget colorDefaultFilter() {
+      final styleButtonColor = getColorsForStyle(style);
+      return ColorFiltered(
+        colorFilter: ColorFilter.mode(styleButtonColor.icon!, BlendMode.srcIn),
+        child: icon,
+      );
+    }
+
+    Widget _colorEnableFilter() {
+      return ColorFiltered(
+        colorFilter: const ColorFilter.mode(Colors.grey, BlendMode.srcIn),
+        child: icon,
+      );
+    }
+
+    final styleButtonColor = getColorsForStyle(style);
+
+    if (icon != null && fullWidth == false) {
       return TextButton.icon(
         style: FilledButton.styleFrom(
           minimumSize:
@@ -116,17 +127,15 @@ class _OdsTextButtonState extends State<OdsTextButton> {
               const EdgeInsets.fromLTRB(spacingM, spacingS, spacingL, spacingS),
           backgroundColor: styleButtonColor.background,
         ),
-        onPressed: widget.onClick,
+        onPressed: onClick,
         icon: ExcludeSemantics(
           excluding: true,
-          child: widget.onClick != null
-              ? colorDefaultFilter()
-              : _colorEnableFilter(),
+          child: onClick != null ? colorDefaultFilter() : _colorEnableFilter(),
         ),
         label: Text(
-          widget.text,
+          text,
           style: TextStyle(
-            color: widget.onClick != null
+            color: onClick != null
                 ? styleButtonColor.text
                 : styleButtonColor.textDisabled,
           ),
@@ -134,21 +143,20 @@ class _OdsTextButtonState extends State<OdsTextButton> {
       );
     }
 
-    if (widget.icon != null && widget.fullWidth == true) {
+    if (icon != null && fullWidth == true) {
       return SizedBox(
         width: double.infinity,
         child: TextButton.icon(
-          onPressed: widget.onClick,
+          onPressed: onClick,
           icon: ExcludeSemantics(
             excluding: true,
-            child: widget.onClick != null
-                ? colorDefaultFilter()
-                : _colorEnableFilter(),
+            child:
+                onClick != null ? colorDefaultFilter() : _colorEnableFilter(),
           ),
           label: Text(
-            widget.text,
+            text,
             style: TextStyle(
-              color: widget.onClick != null
+              color: onClick != null
                   ? styleButtonColor.text
                   : styleButtonColor.textDisabled,
             ),
@@ -159,17 +167,17 @@ class _OdsTextButtonState extends State<OdsTextButton> {
       );
     }
 
-    if (widget.fullWidth == true) {
+    if (fullWidth == true) {
       return SizedBox(
         width: double.infinity,
         child: TextButton(
-          onPressed: widget.onClick,
+          onPressed: onClick,
           style: FilledButton.styleFrom(
               backgroundColor: styleButtonColor.background),
           child: Text(
-            widget.text,
+            text,
             style: TextStyle(
-              color: widget.onClick != null
+              color: onClick != null
                   ? styleButtonColor.text
                   : styleButtonColor.textDisabled,
             ),
@@ -179,33 +187,17 @@ class _OdsTextButtonState extends State<OdsTextButton> {
     }
 
     return TextButton(
-      onPressed: widget.onClick,
+      onPressed: onClick,
       style:
           FilledButton.styleFrom(backgroundColor: styleButtonColor.background),
       child: Text(
-        widget.text,
+        text,
         style: TextStyle(
-          color: widget.onClick != null
+          color: onClick != null
               ? styleButtonColor.text
               : styleButtonColor.textDisabled,
         ),
       ),
-    );
-  }
-
-  ///Color Filter
-  Widget colorDefaultFilter() {
-    final styleButtonColor = getColorsForStyle(widget.style);
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(styleButtonColor.icon!, BlendMode.srcIn),
-      child: widget.icon,
-    );
-  }
-
-  Widget _colorEnableFilter() {
-    return ColorFiltered(
-      colorFilter: const ColorFilter.mode(Colors.grey, BlendMode.srcIn),
-      child: widget.icon,
     );
   }
 }

--- a/library/lib/components/button/segmented/button_icon/ods_button_icon.dart
+++ b/library/lib/components/button/segmented/button_icon/ods_button_icon.dart
@@ -28,7 +28,7 @@ enum OdsButtonIconStyle {
 ///
 /// Displays a customizable button with an optional icon and a title.
 /// The button can expand to full screen width if specified.
-class OdsButtonIcon extends StatefulWidget {
+class OdsButtonIcon extends StatelessWidget {
   /// Creates an ODS Button.
   ///
   /// * [isSelected] - The optional selection state of the icon button.
@@ -67,11 +67,6 @@ class OdsButtonIcon extends StatefulWidget {
   final OdsButtonIconStyle style;
 
   @override
-  State<OdsButtonIcon> createState() => _OdsButtonState();
-}
-
-class _OdsButtonState extends State<OdsButtonIcon> {
-  @override
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
     ButtonStyle? getColorsForStyle(OdsButtonIconStyle? style) {
@@ -79,102 +74,103 @@ class _OdsButtonState extends State<OdsButtonIcon> {
         case OdsButtonIconStyle.functionalStandard:
           return null;
         case OdsButtonIconStyle.functionalFilled:
-          return enabledFilledButtonStyle(widget.isSelected, colors);
+          return enabledFilledButtonStyle(isSelected, colors);
         case OdsButtonIconStyle.functionalTonal:
-          return enabledFilledTonalButtonStyle(widget.isSelected, colors);
+          return enabledFilledTonalButtonStyle(isSelected, colors);
         case OdsButtonIconStyle.functionalOutlined:
-          return enabledOutlinedButtonStyle(widget.isSelected, colors);
+          return enabledOutlinedButtonStyle(isSelected, colors);
       }
+      return null;
     }
 
-    final styleButtonColor = getColorsForStyle(widget.style);
+    final styleButtonColor = getColorsForStyle(style);
 
     return IconButton(
       visualDensity: VisualDensity.standard,
-      isSelected: widget.isSelected,
+      isSelected: isSelected,
       icon: colorDeselectedFilter(colors),
-      selectedIcon: colorSelectedFilter(widget.isSelected, colors),
-      onPressed: widget.isEnabled ? widget.onClick : null,
+      selectedIcon: colorSelectedFilter(isSelected, colors),
+      onPressed: isEnabled ? onClick : null,
       style: styleButtonColor,
     );
   }
 
   ///Color Filter
   Widget colorDeselectedFilter(ColorScheme colors) {
-    switch (widget.style) {
+    switch (style) {
       case OdsButtonIconStyle.functionalStandard:
         return ColorFiltered(
-          colorFilter: widget.isEnabled
+          colorFilter: isEnabled
               ? ColorFilter.mode(colors.secondary, BlendMode.srcIn)
               : ColorFilter.mode(
                   colors.onSurface.withOpacity(0.38), BlendMode.srcIn),
-          child: widget.icon,
+          child: icon,
         );
       case OdsButtonIconStyle.functionalFilled:
         return ColorFiltered(
-          colorFilter: widget.isEnabled
+          colorFilter: isEnabled
               ? ColorFilter.mode(colors.primary, BlendMode.srcIn)
               : ColorFilter.mode(
                   colors.onSurface.withOpacity(0.38), BlendMode.srcIn),
-          child: widget.icon,
+          child: icon,
         );
       case OdsButtonIconStyle.functionalTonal:
         return ColorFiltered(
-          colorFilter: widget.isEnabled
+          colorFilter: isEnabled
               ? ColorFilter.mode(colors.secondary, BlendMode.srcIn)
               : ColorFilter.mode(
                   colors.onSurface.withOpacity(0.38), BlendMode.srcIn),
-          child: widget.icon,
+          child: icon,
         );
       case OdsButtonIconStyle.functionalOutlined:
         return ColorFiltered(
-          colorFilter: widget.isEnabled
+          colorFilter: isEnabled
               ? ColorFilter.mode(colors.secondary, BlendMode.srcIn)
               : ColorFilter.mode(
                   colors.onSurface.withOpacity(0.38), BlendMode.srcIn),
-          child: widget.icon,
+          child: icon,
         );
       default:
-        return widget.icon;
+        return icon;
     }
   }
 
   Widget? colorSelectedFilter(bool selected, ColorScheme colors) {
-    switch (widget.style) {
+    switch (style) {
       case OdsButtonIconStyle.functionalStandard:
         return ColorFiltered(
-          colorFilter: widget.isEnabled
+          colorFilter: isEnabled
               ? ColorFilter.mode(colors.primary, BlendMode.srcIn)
               : ColorFilter.mode(
                   colors.onSurface.withOpacity(0.38), BlendMode.srcIn),
-          child: widget.selectedIcon,
+          child: selectedIcon,
         );
       case OdsButtonIconStyle.functionalFilled:
         return ColorFiltered(
-          colorFilter: widget.isEnabled
+          colorFilter: isEnabled
               ? ColorFilter.mode(colors.onPrimary, BlendMode.srcIn)
               : ColorFilter.mode(
                   colors.onSurface.withOpacity(0.38), BlendMode.srcIn),
-          child: widget.selectedIcon,
+          child: selectedIcon,
         );
       case OdsButtonIconStyle.functionalTonal:
         return ColorFiltered(
-          colorFilter: widget.isEnabled
+          colorFilter: isEnabled
               ? ColorFilter.mode(colors.onSecondary, BlendMode.srcIn)
               : ColorFilter.mode(
                   colors.onSurface.withOpacity(0.38), BlendMode.srcIn),
-          child: widget.selectedIcon,
+          child: selectedIcon,
         );
       case OdsButtonIconStyle.functionalOutlined:
         return ColorFiltered(
-          colorFilter: widget.isEnabled
+          colorFilter: isEnabled
               ? ColorFilter.mode(colors.primary, BlendMode.srcIn)
               : ColorFilter.mode(
                   colors.onSurface.withOpacity(0.38), BlendMode.srcIn),
-          child: widget.selectedIcon,
+          child: selectedIcon,
         );
       default:
-        return widget.selectedIcon;
+        return selectedIcon;
     }
   }
 
@@ -230,7 +226,7 @@ class _OdsButtonState extends State<OdsButtonIcon> {
           ? colors.onSurface.withOpacity(0.12)
           : colors.onSurface.withOpacity(0.12),
       side: BorderSide(
-        color: !widget.isEnabled
+        color: !isEnabled
             ? colors.onSurface.withOpacity(0.38)
             : (selected ? colors.primary : colors.outline),
       ),

--- a/library/lib/components/button/segmented/ods_segmented_button.dart
+++ b/library/lib/components/button/segmented/ods_segmented_button.dart
@@ -16,7 +16,7 @@ import 'package:flutter/material.dart';
 ///
 /// The OdsCheckbox widget represents a checkbox element that can be checked or unchecked.
 /// It allows for handling the checkbox state and triggering a callback when its state changes.
-class OdsSegmentedButton<T> extends StatefulWidget {
+class OdsSegmentedButton<T> extends StatelessWidget {
   /// Creates an ODS RadioButton.
   const OdsSegmentedButton({
     Key? key,
@@ -44,20 +44,12 @@ class OdsSegmentedButton<T> extends StatefulWidget {
   final List<ButtonSegment<T>> segments;
 
   @override
-  State<OdsSegmentedButton<T>> createState() => _OdsSegmentedButtonState<T>();
-}
-
-class _OdsSegmentedButtonState<T> extends State<OdsSegmentedButton<T>> {
-  @override
   Widget build(BuildContext context) {
     return Semantics(
       child: SegmentedButton<T>(
-        segments: widget.segments.length > 5
-            ? widget.segments.sublist(0, 5)
-            : widget.segments,
-        selected: widget.selected,
-        onSelectionChanged:
-            widget.enabled != false ? widget.onSelectionChanged : null,
+        segments: segments.length > 5 ? segments.sublist(0, 5) : segments,
+        selected: selected,
+        onSelectionChanged: enabled != false ? onSelectionChanged : null,
         multiSelectionEnabled: true,
         //emptySelectionAllowed: true,
       ),

--- a/library/lib/components/card/ods_horizontal_card.dart
+++ b/library/lib/components/card/ods_horizontal_card.dart
@@ -26,7 +26,7 @@ enum OdsHorizontalCardImagePosition {
 /// Cards contain content and actions about a single subject.
 ///
 /// A ripple effect is managed on card click.
-class OdsHorizontalCard extends StatefulWidget {
+class OdsHorizontalCard extends StatelessWidget {
   const OdsHorizontalCard({
     Key? key,
     required this.title,
@@ -74,11 +74,6 @@ class OdsHorizontalCard extends StatefulWidget {
   final Function()? onClick;
 
   @override
-  State<OdsHorizontalCard> createState() => _OdsHorizontalCardState();
-}
-
-class _OdsHorizontalCardState extends State<OdsHorizontalCard> {
-  @override
   Widget build(BuildContext context) {
     return Semantics(
       container: true,
@@ -98,24 +93,24 @@ class _OdsHorizontalCardState extends State<OdsHorizontalCard> {
                 child: Material(
                   color: Colors.transparent,
                   child: InkWell(
-                    onTap: widget.onClick,
+                    onTap: onClick,
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Container(
-                          constraints: const BoxConstraints(
-                              minHeight: OdsHorizontalCard._imageMinWidth),
+                          constraints:
+                              const BoxConstraints(minHeight: _imageMinWidth),
                           child: IntrinsicHeight(
                             child: Row(
                               crossAxisAlignment: CrossAxisAlignment.stretch,
                               children: [
-                                if (widget.imagePosition ==
+                                if (imagePosition ==
                                     OdsHorizontalCardImagePosition.start)
                                   ExcludeSemantics(
                                     child: SizedBox(
-                                      width: OdsHorizontalCard._imageWidth,
-                                      height: OdsHorizontalCard._imageHeight,
-                                      child: widget.image,
+                                      width: _imageWidth,
+                                      height: _imageHeight,
+                                      child: image,
                                     ),
                                   ),
                                 Expanded(
@@ -132,23 +127,23 @@ class _OdsHorizontalCardState extends State<OdsHorizontalCard> {
                                           MainAxisAlignment.center,
                                       children: [
                                         Text(
-                                          widget.title,
+                                          title,
                                           style: Theme.of(context)
                                               .textTheme
                                               .titleMedium,
                                         ),
-                                        if (widget.subtitle != null)
+                                        if (subtitle != null)
                                           Text(
-                                            widget.subtitle!,
+                                            subtitle!,
                                             style: Theme.of(context)
                                                 .textTheme
                                                 .bodyMedium,
                                           ),
-                                        if (widget.text != null)
+                                        if (text != null)
                                           Padding(
                                             padding: const EdgeInsets.only(
                                                 top: spacingM),
-                                            child: Text(widget.text!,
+                                            child: Text(text!,
                                                 style: Theme.of(context)
                                                     .textTheme
                                                     .bodyMedium,
@@ -160,21 +155,20 @@ class _OdsHorizontalCardState extends State<OdsHorizontalCard> {
                                     ),
                                   ),
                                 ),
-                                if (widget.imagePosition ==
+                                if (imagePosition ==
                                     OdsHorizontalCardImagePosition.end)
                                   ExcludeSemantics(
                                     child: SizedBox(
                                       width: OdsHorizontalCard._imageWidth,
                                       height: OdsHorizontalCard._imageHeight,
-                                      child:
-                                          ExcludeSemantics(child: widget.image),
+                                      child: ExcludeSemantics(child: image),
                                     ),
                                   )
                               ],
                             ),
                           ),
                         ),
-                        if (widget.divider != false)
+                        if (divider != false)
                           Divider(
                             height: 0,
                             thickness: 1,
@@ -182,21 +176,21 @@ class _OdsHorizontalCardState extends State<OdsHorizontalCard> {
                             color: Theme.of(context)
                                 .colorScheme
                                 .onSurface
-                                .withOpacity(OdsHorizontalCard._dividerOpacity),
+                                .withOpacity(_dividerOpacity),
                           ),
                         SingleChildScrollView(
                           scrollDirection: Axis.horizontal,
                           child: Row(
                             children: [
-                              if (widget.firstButton != null)
+                              if (firstButton != null)
                                 Padding(
                                   padding: const EdgeInsets.all(spacingS),
-                                  child: widget.firstButton,
+                                  child: firstButton,
                                 ),
-                              if (widget.secondButton != null)
+                              if (secondButton != null)
                                 Padding(
                                   padding: const EdgeInsets.all(spacingS),
-                                  child: widget.secondButton,
+                                  child: secondButton,
                                 ),
                             ],
                           ),

--- a/library/lib/components/card/ods_small_card.dart
+++ b/library/lib/components/card/ods_small_card.dart
@@ -19,7 +19,7 @@ import 'package:ods_flutter/theme/ods_theme.dart';
 /// Cards contain content and actions about a single subject.
 ///
 /// A ripple effect is managed on card click.
-class OdsSmallCard extends StatefulWidget {
+class OdsSmallCard extends StatelessWidget {
   /// Creates an ODS Small card.
   const OdsSmallCard({
     Key? key,
@@ -45,16 +45,11 @@ class OdsSmallCard extends StatefulWidget {
   final Function()? onTap;
 
   @override
-  State<OdsSmallCard> createState() => _OdsSmallCardState();
-}
-
-class _OdsSmallCardState extends State<OdsSmallCard> {
-  @override
   Widget build(BuildContext context) {
     return MergeSemantics(
       child: Semantics(
-        button: widget.onTap != null ? true : false,
-        onTap: widget.onTap,
+        button: onTap != null ? true : false,
+        onTap: onTap,
         child: Stack(
           children: [
             SizedBox(
@@ -71,7 +66,7 @@ class _OdsSmallCardState extends State<OdsSmallCard> {
                     SizedBox(
                       width: double.infinity,
                       height: OdsSmallCard._imageHeight,
-                      child: ExcludeSemantics(child: widget.image),
+                      child: ExcludeSemantics(child: image),
                     ),
                     Padding(
                       padding: const EdgeInsets.all(spacingM),
@@ -79,13 +74,13 @@ class _OdsSmallCardState extends State<OdsSmallCard> {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              widget.title,
+                              title,
                               style: Theme.of(context).textTheme.titleMedium,
                               overflow: TextOverflow.ellipsis,
                             ),
-                            if (widget.subtitle != null)
+                            if (subtitle != null)
                               Text(
-                                widget.subtitle!,
+                                subtitle!,
                                 style: Theme.of(context).textTheme.bodyMedium,
                                 overflow: TextOverflow.ellipsis,
                               ),
@@ -95,12 +90,12 @@ class _OdsSmallCardState extends State<OdsSmallCard> {
                 ),
               ),
             ),
-            if (widget.onTap != null)
+            if (onTap != null)
               Positioned.fill(
                 child: Material(
                   color: Colors.transparent,
                   child: InkWell(
-                    onTap: widget.onTap,
+                    onTap: onTap,
                   ),
                 ),
               )

--- a/library/lib/components/card/ods_vertical_header_first_card.dart
+++ b/library/lib/components/card/ods_vertical_header_first_card.dart
@@ -20,7 +20,7 @@ import 'package:ods_flutter/guidelines/spacings.dart';
 /// Cards contain content and actions about a single subject.
 ///
 /// A ripple effect is managed on card click.
-class OdsVerticalHeaderFirstCard extends StatefulWidget {
+class OdsVerticalHeaderFirstCard extends StatelessWidget {
   const OdsVerticalHeaderFirstCard({
     Key? key,
     required this.title,
@@ -62,13 +62,6 @@ class OdsVerticalHeaderFirstCard extends StatefulWidget {
   final Function()? onClick;
 
   @override
-  State<OdsVerticalHeaderFirstCard> createState() =>
-      _OdsVerticalHeaderFirstCardState();
-}
-
-class _OdsVerticalHeaderFirstCardState
-    extends State<OdsVerticalHeaderFirstCard> {
-  @override
   Widget build(BuildContext context) {
     return IntrinsicHeight(
       child: SizedBox(
@@ -77,30 +70,29 @@ class _OdsVerticalHeaderFirstCardState
           clipBehavior: Clip.antiAlias,
           elevation: 2,
           child: InkWell(
-            onTap: widget.onClick,
+            onTap: onClick,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Padding(
                   padding: const EdgeInsets.only(bottom: spacingXs),
                   child: ListTile(
-                    leading: widget.thumbnail,
-                    title: Text(widget.title!,
+                    leading: thumbnail,
+                    title: Text(title!,
                         style: Theme.of(context).textTheme.titleLarge,
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis),
-                    subtitle:
-                        widget.subtitle != null ? Text(widget.subtitle!) : null,
+                    subtitle: subtitle != null ? Text(subtitle!) : null,
                   ),
                 ),
                 Expanded(
                   child: SizedBox(
                     width: double.infinity,
                     height: OdsVerticalHeaderFirstCard._imageHeight,
-                    child: ExcludeSemantics(child: widget.image),
+                    child: ExcludeSemantics(child: image),
                   ),
                 ),
-                if (widget.text != null && widget.text!.isNotEmpty)
+                if (text != null && text!.isNotEmpty)
                   Padding(
                     padding: const EdgeInsets.only(
                         left: spacingM,
@@ -108,15 +100,15 @@ class _OdsVerticalHeaderFirstCardState
                         top: spacingM,
                         bottom: spacingXs),
                     child: Text(
-                      widget.text!,
+                      text!,
                     ),
                   ),
-                if (widget.firstButton != null || widget.secondButton != null)
+                if (firstButton != null || secondButton != null)
                   ButtonBar(
                     alignment: MainAxisAlignment.start,
                     children: [
-                      if (widget.firstButton != null) widget.firstButton!,
-                      if (widget.secondButton != null) widget.secondButton!,
+                      if (firstButton != null) firstButton!,
+                      if (secondButton != null) secondButton!,
                     ],
                   ),
               ],

--- a/library/lib/components/card/ods_vertical_image_first_card.dart
+++ b/library/lib/components/card/ods_vertical_image_first_card.dart
@@ -20,7 +20,7 @@ import 'package:ods_flutter/guidelines/spacings.dart';
 /// Cards contain content and actions about a single subject.
 ///
 /// A ripple effect is managed on card click.
-class OdsVerticalImageFirstCard extends StatefulWidget {
+class OdsVerticalImageFirstCard extends StatelessWidget {
   /// Creates an ODS vertical image first card.
   const OdsVerticalImageFirstCard({
     Key? key,
@@ -58,12 +58,6 @@ class OdsVerticalImageFirstCard extends StatefulWidget {
   final Function()? onClick;
 
   @override
-  State<OdsVerticalImageFirstCard> createState() =>
-      _OdsVerticalImageFirstCardState();
-}
-
-class _OdsVerticalImageFirstCardState extends State<OdsVerticalImageFirstCard> {
-  @override
   Widget build(BuildContext context) {
     return Stack(
       children: [
@@ -76,7 +70,7 @@ class _OdsVerticalImageFirstCardState extends State<OdsVerticalImageFirstCard> {
               child: Material(
                 color: Colors.transparent,
                 child: InkWell(
-                  onTap: widget.onClick,
+                  onTap: onClick,
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
@@ -84,38 +78,38 @@ class _OdsVerticalImageFirstCardState extends State<OdsVerticalImageFirstCard> {
                         child: SizedBox(
                           width: double.infinity,
                           height: OdsVerticalImageFirstCard._imageHeight,
-                          child: ExcludeSemantics(child: widget.image),
+                          child: ExcludeSemantics(child: image),
                         ),
                       ),
                       Padding(
                         padding: const EdgeInsets.only(
                             top: spacingM, left: spacingM),
                         child: Text(
-                          widget.title,
+                          title,
                           style: Theme.of(context).textTheme.titleLarge,
                         ),
                       ),
-                      if (widget.subtitle != null)
+                      if (subtitle != null)
                         Padding(
                           padding: const EdgeInsets.only(left: spacingM),
                           child: Text(
-                            widget.subtitle!,
+                            subtitle!,
                             style: Theme.of(context).textTheme.bodyMedium,
                           ),
                         ),
-                      if (widget.text != null && widget.text!.isNotEmpty)
+                      if (text != null && text!.isNotEmpty)
                         Padding(
                           padding: const EdgeInsets.only(
                               left: spacingM, right: spacingM, top: spacingS),
                           child: Text(
-                            widget.text!,
+                            text!,
                           ),
                         ),
                       ButtonBar(
                         alignment: MainAxisAlignment.start,
                         children: [
-                          if (widget.firstButton != null) widget.firstButton!,
-                          if (widget.secondButton != null) widget.secondButton!,
+                          if (firstButton != null) firstButton!,
+                          if (secondButton != null) secondButton!,
                         ],
                       ),
                     ],

--- a/library/lib/components/checkbox/ods_checkbox.dart
+++ b/library/lib/components/checkbox/ods_checkbox.dart
@@ -17,7 +17,7 @@ import 'package:ods_flutter/l10n/gen/ods_localizations.dart';
 ///
 /// The OdsCheckbox widget represents a checkbox element that can be checked or unchecked.
 /// It allows for handling the checkbox state and triggering a callback when its state changes.
-class OdsCheckbox extends StatefulWidget {
+class OdsCheckbox extends StatelessWidget {
   /// Creates an ODS Checkboxes.
   const OdsCheckbox({
     Key? key,
@@ -40,28 +40,23 @@ class OdsCheckbox extends StatefulWidget {
   final bool indeterminate;
 
   @override
-  State<OdsCheckbox> createState() => _OdsCheckboxState();
-}
-
-class _OdsCheckboxState extends State<OdsCheckbox> {
-  @override
   Widget build(BuildContext context) {
-    String checkBoxValue = widget.checked == null
+    String checkBoxValue = checked == null
         ? OdsLocalizations.of(context)!.componentCheckboxesIndeterminate
-        : widget.checked ?? false
+        : checked ?? false
             ? OdsLocalizations.of(context)!.componentCheckboxesChecked
             : OdsLocalizations.of(context)!.componentCheckboxesUnchecked;
 
     return Semantics(
       value: checkBoxValue,
-      enabled: widget.enabled,
+      enabled: enabled,
       hint: OdsLocalizations.of(context)!.componentCheckboxes,
       excludeSemantics: true,
       child: Checkbox(
         autofocus: true,
-        value: widget.checked,
-        onChanged: widget.enabled != false ? widget.onCheckedChange : null,
-        tristate: widget.indeterminate,
+        value: checked,
+        onChanged: enabled != false ? onCheckedChange : null,
+        tristate: indeterminate,
       ),
     );
   }

--- a/library/lib/components/chips/ods_action_chips.dart
+++ b/library/lib/components/chips/ods_action_chips.dart
@@ -16,7 +16,7 @@ import 'package:flutter/material.dart';
 ///
 /// Displays a customizable chips with an optional action.
 ///
-class OdsActionChip extends StatefulWidget {
+class OdsActionChip extends StatelessWidget {
   /// Creates an ODS Action Chips.
   ///
   /// * [text] - Text displayed in the chip.
@@ -43,18 +43,14 @@ class OdsActionChip extends StatefulWidget {
   final bool? enabled;
 
   @override
-  State<OdsActionChip> createState() => _OdsActionChipState();
-}
-
-class _OdsActionChipState extends State<OdsActionChip> {
-  @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
+      label: text,
       child: ActionChip(
-        label: Text(widget.text),
-        avatar: ExcludeSemantics(child: widget.leadingIcon),
-        onPressed: widget.enabled != false ? widget.onClick : null,
+        label: Text(text),
+        avatar: ExcludeSemantics(child: leadingIcon),
+        onPressed: enabled != false ? onClick : null,
       ),
     );
   }

--- a/library/lib/components/chips/ods_choice_chips.dart
+++ b/library/lib/components/chips/ods_choice_chips.dart
@@ -18,7 +18,7 @@ import 'ods_chip_common.dart';
 ///
 /// Displays a customizable chips with an optional action.
 ///
-class OdsChoiceChip extends StatefulWidget {
+class OdsChoiceChip extends StatelessWidget {
   /// Creates an ODS Choice Chip.
   ///
   /// * [text] - Text to be displayed into the chip
@@ -52,19 +52,14 @@ class OdsChoiceChip extends StatefulWidget {
   final OdsChipLeadingAvatar? leadingAvatar;
 
   @override
-  State<OdsChoiceChip> createState() => _OdsChoiceChipState();
-}
-
-class _OdsChoiceChipState extends State<OdsChoiceChip> {
-  @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
       child: ChoiceChip(
-        label: Text(widget.text, style: Theme.of(context).textTheme.bodyMedium),
-        onSelected: widget.enabled != false ? widget.onClick : null,
-        selected: widget.selected,
-        avatar: widget.leadingAvatar,
+        label: Text(text),
+        onSelected: enabled != false ? onClick : null,
+        selected: selected,
+        avatar: leadingAvatar,
       ),
     );
   }

--- a/library/lib/components/chips/ods_filter_chips.dart
+++ b/library/lib/components/chips/ods_filter_chips.dart
@@ -16,7 +16,7 @@ import 'package:flutter/material.dart';
 ///
 /// Displays a customizable chips with an optional action.
 ///
-class OdsFilterChip extends StatefulWidget {
+class OdsFilterChip extends StatelessWidget {
   /// Creates an ODS Fliter Chip.
   ///
   /// * [text] - Text to be displayed into the chip
@@ -50,48 +50,15 @@ class OdsFilterChip extends StatefulWidget {
   final Widget? leadingAvatar;
 
   @override
-  State<OdsFilterChip> createState() => _OdsFilterChipState();
-}
-
-class _OdsFilterChipState extends State<OdsFilterChip> {
-  @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
       child: FilterChip(
-        label: Text(widget.text, style: Theme.of(context).textTheme.bodyMedium),
-        onSelected: widget.enabled != false ? widget.onClick : null,
-        selected: widget.selected,
-        avatar: widget.leadingAvatar,
+        label: Text(text),
+        onSelected: enabled != false ? onClick : null,
+        selected: selected,
+        avatar: leadingAvatar,
       ),
     );
-
-    /*
-    return Semantics(
-      button: true,
-      label: widget.label,
-      child: ChipTheme(
-        data: ChipThemeData(
-          iconTheme: const IconThemeData(color: black900),
-          checkmarkColor: black900,
-          selectedColor: orange200,
-          deleteIconColor: black900,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(20.0),
-          ),
-          labelStyle: const TextStyle(
-            color: ChipLabelColor(),
-          ),
-        ),
-        child: FilterChip(
-          label: Text(widget.label),
-          avatar: widget.avatar,
-          selected: widget.isSelected,
-          onSelected: widget.onSelected,
-        ),
-      ),
-    );
-
-     */
   }
 }

--- a/library/lib/components/chips/ods_input_chips.dart
+++ b/library/lib/components/chips/ods_input_chips.dart
@@ -17,7 +17,7 @@ import 'package:ods_flutter/theme/ods_palette.dart';
 ///
 /// Displays a customizable chips with an optional action.
 ///
-class OdsInputChip extends StatefulWidget {
+class OdsInputChip extends StatelessWidget {
   /// Creates an ODS Action Chips.
   ///
   /// * [text] - Text displayed in the chip.
@@ -53,11 +53,6 @@ class OdsInputChip extends StatefulWidget {
   final bool enabled;
 
   @override
-  State<OdsInputChip> createState() => _OdsInputChipsState();
-}
-
-class _OdsInputChipsState extends State<OdsInputChip> {
-  @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
@@ -70,20 +65,19 @@ class _OdsInputChipsState extends State<OdsInputChip> {
           ),
           side: BorderSide(
             color: Theme.of(context).brightness == Brightness.light
-                ? (widget.enabled ? black900 : grey400)
+                ? (enabled ? black900 : grey400)
                 : Theme.of(context).brightness == Brightness.dark
-                    ? (widget.enabled ? white100 : grey800)
+                    ? (enabled ? white100 : grey800)
                     : grey800,
           ),
         ),
         child: MergeSemantics(
           child: InputChip(
-            label: Text(widget.text,
-                style: Theme.of(context).textTheme.bodyMedium),
-            avatar: widget.leadingAvatar ?? widget.leadingIcon,
+            label: Text(text, style: Theme.of(context).textTheme.bodyMedium),
+            avatar: leadingAvatar ?? leadingIcon,
             deleteIcon: null,
-            onPressed: widget.enabled != false ? widget.onClick : null,
-            onDeleted: widget.onCancel,
+            onPressed: enabled != false ? onClick : null,
+            onDeleted: onCancel,
           ),
         ),
       ),

--- a/library/lib/components/dialogs/ods_alert_dialog.dart
+++ b/library/lib/components/dialogs/ods_alert_dialog.dart
@@ -35,14 +35,7 @@ class OdsAlertDialogButton {
 ///
 /// Displays a customizable dialog with an optional dismiss button.
 /// The dialog can expand to full screen width if specified.
-class OdsAlertDialog extends StatefulWidget {
-  const OdsAlertDialog({
-    Key? key,
-  }) : super(key: key);
-
-  @override
-  State<OdsAlertDialog> createState() => _OdsAlertDialogState();
-
+class OdsAlertDialog {
   /// Creates an ODS Alert Dialog.
   ///
   /// * [text] - Text displayed into the dialog which presents the details regarding the Dialog's purpose.
@@ -116,17 +109,5 @@ class OdsAlertDialog extends StatefulWidget {
         ),
       ),
     );
-  }
-}
-
-class _OdsAlertDialogState extends State<OdsAlertDialog> {
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Container();
   }
 }

--- a/library/lib/components/floating_action_button/ods_fab.dart
+++ b/library/lib/components/floating_action_button/ods_fab.dart
@@ -16,7 +16,7 @@ import 'package:flutter/material.dart';
 ///
 /// Displays a customizable floating action button with an optional icon and a tooltip.
 /// The floating action button can expand to full screen width if specified.
-class OdsFloatingActionButton extends StatefulWidget {
+class OdsFloatingActionButton extends StatelessWidget {
   /// Creates an ODS Floating Action Button.
   ///
   /// * [onClick] - The callback function when the button is pressed.
@@ -39,20 +39,14 @@ class OdsFloatingActionButton extends StatefulWidget {
   final String? semanticsLabel;
 
   @override
-  State<OdsFloatingActionButton> createState() =>
-      _OdsFloatingActionButtonState();
-}
-
-class _OdsFloatingActionButtonState extends State<OdsFloatingActionButton> {
-  @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
-      label: widget.semanticsLabel,
+      label: semanticsLabel,
       excludeSemantics: true,
       child: FloatingActionButton(
-        onPressed: widget.onClick,
-        child: widget.icon,
+        onPressed: onClick,
+        child: icon,
       ),
     );
   }

--- a/library/lib/components/floating_action_button/ods_fab_extended.dart
+++ b/library/lib/components/floating_action_button/ods_fab_extended.dart
@@ -16,7 +16,7 @@ import 'package:flutter/material.dart';
 ///
 /// Displays a customizable floating action button with an optional icon and a tooltip.
 /// The floating action button
-class OdsExtendedFloatingActionButton extends StatefulWidget {
+class OdsExtendedFloatingActionButton extends StatelessWidget {
   /// Creates an ODS Floating Action Button.
   ///
   /// * [onClick] - The callback function when the button is pressed.
@@ -38,20 +38,13 @@ class OdsExtendedFloatingActionButton extends StatefulWidget {
   final Widget? icon;
 
   @override
-  State<OdsExtendedFloatingActionButton> createState() =>
-      _OdsExtendedFloatingActionButtonState();
-}
-
-class _OdsExtendedFloatingActionButtonState
-    extends State<OdsExtendedFloatingActionButton> {
-  @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
       child: FloatingActionButton.extended(
-        onPressed: widget.onClick,
-        label: Text(widget.text),
-        icon: widget.icon,
+        onPressed: onClick,
+        label: Text(text),
+        icon: icon,
       ),
     );
   }

--- a/library/lib/components/floating_action_button/ods_fab_large.dart
+++ b/library/lib/components/floating_action_button/ods_fab_large.dart
@@ -16,7 +16,7 @@ import 'package:flutter/material.dart';
 ///
 /// Displays a customizable floating action button with an optional icon and a tooltip.
 /// The floating action button
-class OdsLargeFloatingActionButton extends StatefulWidget {
+class OdsLargeFloatingActionButton extends StatelessWidget {
   /// Creates an ODS Floating Action Button.
   ///
   /// * [icon] - The icon widget displayed inside the button.
@@ -39,20 +39,13 @@ class OdsLargeFloatingActionButton extends StatefulWidget {
   final String? semanticsLabel;
 
   @override
-  State<OdsLargeFloatingActionButton> createState() =>
-      _OdsLargeFloatingActionButtonState();
-}
-
-class _OdsLargeFloatingActionButtonState
-    extends State<OdsLargeFloatingActionButton> {
-  @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
-      label: widget.semanticsLabel,
+      label: semanticsLabel,
       child: FloatingActionButton.large(
-        onPressed: widget.onClick,
-        child: widget.icon,
+        onPressed: onClick,
+        child: icon,
       ),
     );
   }

--- a/library/lib/components/floating_action_button/ods_fab_small.dart
+++ b/library/lib/components/floating_action_button/ods_fab_small.dart
@@ -16,7 +16,7 @@ import 'package:flutter/material.dart';
 ///
 /// Displays a customizable floating action button with an optional icon and a tooltip.
 /// The floating action button
-class OdsSmallFloatingActionButton extends StatefulWidget {
+class OdsSmallFloatingActionButton extends StatelessWidget {
   /// Creates an ODS Floating Action Button.
   ///
   /// * [onClick] - The callback function when the button is pressed.
@@ -39,20 +39,13 @@ class OdsSmallFloatingActionButton extends StatefulWidget {
   final String? semanticsLabel;
 
   @override
-  State<OdsSmallFloatingActionButton> createState() =>
-      _OdsSmallFloatingActionButtonState();
-}
-
-class _OdsSmallFloatingActionButtonState
-    extends State<OdsSmallFloatingActionButton> {
-  @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
-      label: widget.semanticsLabel,
+      label: semanticsLabel,
       child: FloatingActionButton.small(
-        onPressed: widget.onClick,
-        child: widget.icon,
+        onPressed: onClick,
+        child: icon,
       ),
     );
   }

--- a/library/lib/components/lists/ods_list_checkbox.dart
+++ b/library/lib/components/lists/ods_list_checkbox.dart
@@ -17,7 +17,7 @@ import 'package:ods_flutter/l10n/gen/ods_localizations.dart';
 ///
 /// The OdsListCheckbox widget represents a checkbox list element that can be checked or unchecked.
 /// It allows for handling the checkbox list state and triggering a callback when its state changes.
-class OdsListCheckbox extends StatefulWidget {
+class OdsListCheckbox extends StatelessWidget {
   /// Creates an ODS Checkbox list.
   const OdsListCheckbox({
     Key? key,
@@ -44,32 +44,27 @@ class OdsListCheckbox extends StatefulWidget {
   final bool indeterminate;
 
   @override
-  State<OdsListCheckbox> createState() => _OdsListCheckboxState();
-}
-
-class _OdsListCheckboxState extends State<OdsListCheckbox> {
-  @override
   Widget build(BuildContext context) {
-    String checkBoxValue = widget.checked == null
+    String checkBoxValue = checked == null
         ? OdsLocalizations.of(context)!.componentCheckboxesIndeterminate
-        : widget.checked ?? false
+        : checked ?? false
             ? OdsLocalizations.of(context)!.componentCheckboxesChecked
             : OdsLocalizations.of(context)!.componentCheckboxesUnchecked;
 
     return Semantics(
-      label: widget.title,
+      label: title,
       value: checkBoxValue,
-      enabled: widget.enabled,
+      enabled: enabled,
       hint: OdsLocalizations.of(context)!.componentCheckboxes,
       excludeSemantics: true,
       child: CheckboxListTile(
         title: Text(
-          widget.title,
+          title,
           style: Theme.of(context).textTheme.titleMedium,
         ),
-        value: widget.checked,
-        onChanged: widget.enabled != false ? widget.onCheckedChange : null,
-        tristate: widget.indeterminate,
+        value: checked,
+        onChanged: enabled != false ? onCheckedChange : null,
+        tristate: indeterminate,
       ),
     );
   }

--- a/library/lib/components/lists/ods_list_item.dart
+++ b/library/lib/components/lists/ods_list_item.dart
@@ -18,7 +18,7 @@ import 'package:ods_flutter/components/divider/ods_divider.dart';
 /// This list contains content and actions about a single subject.
 ///
 /// A ripple effect is managed on list tile.
-class OdsListItem extends StatefulWidget {
+class OdsListItem extends StatelessWidget {
   /// Creates an ODS List selection.
   const OdsListItem({
     Key? key,
@@ -66,73 +66,67 @@ class OdsListItem extends StatefulWidget {
   final void Function()? onClick;
 
   @override
-  State<OdsListItem> createState() => _OdsListItemState();
-}
-
-class _OdsListItemState extends State<OdsListItem> {
-  @override
   Widget build(BuildContext context) {
     return Semantics(
       container: true,
       child: MergeSemantics(
         child: Column(
           children: [
-            if (widget.onChangedSwitch != null)
+            if (onChangedSwitch != null)
               SwitchListTile(
-                secondary: widget.image,
+                secondary: image,
                 title: Text(
-                  widget.title,
+                  title,
                   style: Theme.of(context).textTheme.titleSmall,
                 ),
-                subtitle: widget.subtitle != null
+                subtitle: subtitle != null
                     ? Text(
-                        widget.subtitle!,
+                        subtitle!,
                         style: Theme.of(context).textTheme.bodyMedium,
                       )
                     : null,
-                value: widget.value ?? false,
-                onChanged: widget.onChangedSwitch,
+                value: value ?? false,
+                onChanged: onChangedSwitch,
               ),
-            if (widget.onChangedCheckBox != null)
+            if (onChangedCheckBox != null)
               CheckboxListTile(
-                secondary: widget.image,
+                secondary: image,
                 title: Text(
-                  widget.title,
+                  title,
                   style: Theme.of(context).textTheme.titleSmall,
                 ),
-                subtitle: widget.subtitle != null
+                subtitle: subtitle != null
                     ? Text(
-                        widget.subtitle!,
+                        subtitle!,
                         style: Theme.of(context).textTheme.bodyMedium,
                       )
                     : null,
-                value: widget.value ?? false,
-                onChanged: widget.onChangedCheckBox,
+                value: value ?? false,
+                onChanged: onChangedCheckBox,
               ),
-            if (widget.onChangedSwitch == null &&
-                widget.onChangedCheckBox == null)
+            if (onChangedSwitch == null && onChangedCheckBox == null)
               ListTile(
-                leading: widget.image,
+                leading: image,
                 title: Text(
-                  widget.title,
+                  title,
                   style: Theme.of(context).textTheme.titleSmall,
                 ),
-                subtitle: widget.subtitle != null
+                subtitle: subtitle != null
                     ? Text(
-                        widget.subtitle!,
+                        subtitle!,
                         style: Theme.of(context).textTheme.bodyLarge,
                       )
                     : null,
                 trailing: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (widget.text != null) Text(widget.text!),
-                    if (widget.icon != null) widget.icon!, // icon-2
+                    if (text != null) Text(text!),
+                    if (icon != null) icon!, // icon-2
                   ],
                 ),
-                onTap: widget.onClick,
+                onTap: onClick,
               ),
-            if (widget.divider != null) const OdsDivider(),
+            if (divider != null) const OdsDivider(),
           ],
         ),
       ),

--- a/library/lib/components/lists/ods_list_radio_button.dart
+++ b/library/lib/components/lists/ods_list_radio_button.dart
@@ -17,7 +17,7 @@ import 'package:ods_flutter/l10n/gen/ods_localizations.dart';
 ///
 /// The OdsCheckbox widget represents a checkbox element that can be checked or unchecked.
 /// It allows for handling the checkbox state and triggering a callback when its state changes.
-class OdsListRadioButton<T> extends StatefulWidget {
+class OdsListRadioButton<T> extends StatelessWidget {
   /// Creates an ODS OdsListRadioButton.
   const OdsListRadioButton({
     Key? key,
@@ -44,30 +44,25 @@ class OdsListRadioButton<T> extends StatefulWidget {
   final bool? enabled;
 
   @override
-  State<OdsListRadioButton<T>> createState() => _OdsRadioButtonState<T>();
-}
-
-class _OdsRadioButtonState<T> extends State<OdsListRadioButton<T>> {
-  @override
   Widget build(BuildContext context) {
-    String radioButtonValue = widget.value == widget.groupValue
+    String radioButtonValue = value == groupValue
         ? OdsLocalizations.of(context)!.componentRadioButtonSelected
         : OdsLocalizations.of(context)!.componentRadioButtonUnselected;
 
     return Semantics(
-      label: widget.title,
+      label: title,
       value: radioButtonValue,
-      enabled: widget.enabled,
+      enabled: enabled,
       hint: OdsLocalizations.of(context)!.componentRadioButton,
       excludeSemantics: true,
       child: RadioListTile<T>(
         title: Text(
-          widget.title,
+          title,
           style: Theme.of(context).textTheme.titleMedium,
         ),
-        value: widget.value,
-        onChanged: widget.enabled != false ? widget.onCheckedChange : null,
-        groupValue: widget.groupValue,
+        value: value,
+        onChanged: enabled != false ? onCheckedChange : null,
+        groupValue: groupValue,
       ),
     );
   }

--- a/library/lib/components/lists/ods_list_switch.dart
+++ b/library/lib/components/lists/ods_list_switch.dart
@@ -20,7 +20,7 @@ import 'package:ods_flutter/l10n/gen/ods_localizations.dart';
 /// It allows for handling the OdsListSwitch list state and triggering a callback when its state changes.
 /// * [checked] determines whether this switch is on or off.
 /// * [onCheckedChange] is called when the user toggles the switch on or off.
-class OdsListSwitch extends StatefulWidget {
+class OdsListSwitch extends StatelessWidget {
   /// Creates an ODS Switch list.
   const OdsListSwitch({
     Key? key,
@@ -47,32 +47,27 @@ class OdsListSwitch extends StatefulWidget {
   final bool? enabled;
 
   @override
-  State<OdsListSwitch> createState() => _OdsListSwitchState();
-}
-
-class _OdsListSwitchState extends State<OdsListSwitch> {
-  @override
   Widget build(BuildContext context) {
-    String switchValue = widget.checked
+    String switchValue = checked
         ? OdsLocalizations.of(context)!.componentSwitchesChecked
         : OdsLocalizations.of(context)!.componentSwitchesUnchecked;
 
     OdsSwitchIcon odsSwitchIcon = OdsSwitchIcon(context);
 
     return Semantics(
-      label: widget.title,
+      label: title,
       value: switchValue,
-      enabled: widget.enabled,
+      enabled: enabled,
       button: true,
       excludeSemantics: true,
       child: SwitchListTile(
         title: Text(
-          widget.title,
+          title,
           style: Theme.of(context).textTheme.titleMedium,
         ),
-        value: widget.checked,
-        onChanged: widget.enabled != false ? widget.onCheckedChange : null,
-        thumbIcon: widget.icon == true ? odsSwitchIcon.thumbIcon : null,
+        value: checked,
+        onChanged: enabled != false ? onCheckedChange : null,
+        thumbIcon: icon == true ? odsSwitchIcon.thumbIcon : null,
       ),
     );
   }

--- a/library/lib/components/menu/item/ods_dropdown_menu_Item.dart
+++ b/library/lib/components/menu/item/ods_dropdown_menu_Item.dart
@@ -18,6 +18,14 @@ import 'package:flutter/material.dart';
 ///
 ///.
 class OdsDropdownMenuItem<T> extends PopupMenuEntry<T> {
+  const OdsDropdownMenuItem({
+    Key? key,
+    required this.text,
+    this.value,
+    this.enabled = true,
+    this.icon,
+  }) : super(key: key);
+
   ///Typically a Text
   final String text;
 
@@ -30,20 +38,11 @@ class OdsDropdownMenuItem<T> extends PopupMenuEntry<T> {
   ///Typically a single-line ListTile for menus with icons
   final Widget? icon;
 
-  const OdsDropdownMenuItem({
-    Key? key,
-    required this.text,
-    this.value,
-    this.enabled = true,
-    this.icon,
-  }) : super(key: key);
-
   @override
-  State<OdsDropdownMenuItem> createState() => _OdsDropdownMenuItemState();
-
-  @override
+  State<OdsDropdownMenuItem<T>> createState() => _OdsDropdownMenuItemState<T>();
 
   /// TODO: implement height
+  @override
   double get height => throw UnimplementedError();
 
   @override
@@ -53,12 +52,7 @@ class OdsDropdownMenuItem<T> extends PopupMenuEntry<T> {
   }
 }
 
-class _OdsDropdownMenuItemState extends State<OdsDropdownMenuItem> {
-  @override
-  void initState() {
-    super.initState();
-  }
-
+class _OdsDropdownMenuItemState<T> extends State<OdsDropdownMenuItem<T>> {
   @override
   Widget build(BuildContext context) {
     Widget? itemMenu;

--- a/library/lib/components/menu/ods_dropdown_menu.dart
+++ b/library/lib/components/menu/ods_dropdown_menu.dart
@@ -18,7 +18,7 @@ import 'package:ods_flutter/components/menu/item/ods_dropdown_menu_Item.dart';
 /// Display a scrolling menu.
 ///
 ///.
-class OdsDropdownMenu<T> extends StatefulWidget {
+class OdsDropdownMenu<T> extends StatelessWidget {
   /// Signature used by PopupMenuButton to lazily construct the items shown when the button is presse
   final List<OdsDropdownMenuItem<T>> items;
 
@@ -32,25 +32,15 @@ class OdsDropdownMenu<T> extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<OdsDropdownMenu> createState() => _OdsDropdownMenuState();
-}
-
-class _OdsDropdownMenuState extends State<OdsDropdownMenu> {
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return Semantics(
       child: PopupMenuButton(
         surfaceTintColor: Colors.white,
         icon: const Icon(Icons.more_vert),
         itemBuilder: (context) {
-          return widget.items;
+          return items;
         },
-        onSelected: widget.selectedItem,
+        onSelected: selectedItem,
       ),
     );
   }

--- a/library/lib/components/menu/ods_exposed_dropdown_menu.dart
+++ b/library/lib/components/menu/ods_exposed_dropdown_menu.dart
@@ -17,9 +17,18 @@ import 'package:flutter/material.dart';
 /// A dropdown menu that can be opened from a TextField.
 ///
 ///.
-class OdsExposedDropdownMenu<T> extends StatefulWidget {
+class OdsExposedDropdownMenu<T> extends StatelessWidget {
+  const OdsExposedDropdownMenu({
+    Key? key,
+    required this.items,
+    required this.label,
+    this.leadingIcon,
+    this.selectedItem,
+    this.enabled = true,
+  }) : super(key: key);
+
   /// Descriptions of the menu items in the [OdsExposedDropdownMenu]
-  final List<DropdownMenuEntry> items;
+  final List<DropdownMenuEntry<T>> items;
 
   /// Text describes the input field
   final String label;
@@ -31,34 +40,15 @@ class OdsExposedDropdownMenu<T> extends StatefulWidget {
   final bool enabled;
 
   /// The callback is called when a selection is made.
-  final Function(T)? selectedItem;
-
-  const OdsExposedDropdownMenu({
-    Key? key,
-    required this.items,
-    required this.label,
-    this.leadingIcon,
-    this.selectedItem,
-    this.enabled = true,
-  }) : super(key: key);
-
-  @override
-  State<OdsExposedDropdownMenu> createState() => _OdsExposedDropdownMenuState();
-}
-
-class _OdsExposedDropdownMenuState extends State<OdsExposedDropdownMenu> {
-  @override
-  void initState() {
-    super.initState();
-  }
+  final ValueChanged<T?>? selectedItem;
 
   @override
   Widget build(BuildContext context) {
     return DropdownMenu(
-      label: Text(widget.label),
-      enabled: widget.enabled,
-      onSelected: widget.selectedItem,
-      dropdownMenuEntries: widget.items,
+      label: Text(label),
+      enabled: enabled,
+      onSelected: selectedItem,
+      dropdownMenuEntries: items,
     );
   }
 }

--- a/library/lib/components/navigation_bar/ods_navigation_bar.dart
+++ b/library/lib/components/navigation_bar/ods_navigation_bar.dart
@@ -17,7 +17,7 @@ import 'package:ods_flutter/components/navigation_bar/ods_navigation_bar_item.da
 ///
 /// The navigation bar displays a list of destinations that can be selected.
 /// It highlights the selected destination and calls a callback when a destination is selected.
-class OdsNavigationBar extends StatefulWidget {
+class OdsNavigationBar extends StatelessWidget {
   /// Creates an ODS Small card.
   const OdsNavigationBar({
     Key? key,
@@ -40,16 +40,11 @@ class OdsNavigationBar extends StatefulWidget {
   final Widget? icon;
 
   @override
-  State<OdsNavigationBar> createState() => _OdsNavigationBarState();
-}
-
-class _OdsNavigationBarState extends State<OdsNavigationBar> {
-  @override
   Widget build(BuildContext context) {
     return NavigationBar(
-      selectedIndex: widget.selectedIndex,
-      onDestinationSelected: widget.onDestinationSelected,
-      destinations: widget.destinations,
+      selectedIndex: selectedIndex,
+      onDestinationSelected: onDestinationSelected,
+      destinations: destinations,
     );
   }
 }

--- a/library/lib/components/navigation_rail/ods_navigation_rail.dart
+++ b/library/lib/components/navigation_rail/ods_navigation_rail.dart
@@ -18,7 +18,7 @@ import 'package:ods_flutter/guidelines/spacings.dart';
 ///
 /// The Navigation Rail is meant to be displayed at the left or right of an app to navigate between
 /// a small number of views, typically between three and five.
-class OdsNavigationRail extends StatefulWidget {
+class OdsNavigationRail extends StatelessWidget {
   /// Creates an ODS Button.
   ///
   /// * [selectedIndex] - The index into [destinations] for the current selected NavigationRailDestination or null if no destination is selected.
@@ -51,11 +51,6 @@ class OdsNavigationRail extends StatefulWidget {
   final Widget? leadingIconSecond;
 
   @override
-  State<OdsNavigationRail> createState() => _OdsNavigationBarState();
-}
-
-class _OdsNavigationBarState extends State<OdsNavigationRail> {
-  @override
   Widget build(BuildContext context) {
     return Row(
       children: [
@@ -66,18 +61,16 @@ class _OdsNavigationBarState extends State<OdsNavigationRail> {
                 constraints: BoxConstraints(minHeight: constraint.maxHeight),
                 child: IntrinsicHeight(
                   child: NavigationRail(
-                    selectedIndex: widget.selectedIndex,
-                    onDestinationSelected: widget.onDestinationSelected,
-                    destinations: widget.destinations,
+                    selectedIndex: selectedIndex,
+                    onDestinationSelected: onDestinationSelected,
+                    destinations: destinations,
                     labelType: NavigationRailLabelType.all,
-                    leading: widget.leadingIconFirst != null ||
-                            widget.leadingIconSecond != null
+                    leading: leadingIconFirst != null ||
+                            leadingIconSecond != null
                         ? Column(
                             children: [
-                              if (widget.leadingIconFirst != null)
-                                widget.leadingIconFirst!,
-                              if (widget.leadingIconSecond != null)
-                                widget.leadingIconSecond!,
+                              if (leadingIconFirst != null) leadingIconFirst!,
+                              if (leadingIconSecond != null) leadingIconSecond!,
                               const SizedBox(height: spacingXl),
                             ],
                           )

--- a/library/lib/components/progress/ods_circular_progress_indicator.dart
+++ b/library/lib/components/progress/ods_circular_progress_indicator.dart
@@ -14,7 +14,7 @@ import 'package:flutter/material.dart';
 import 'package:ods_flutter/guidelines/spacings.dart';
 import 'package:ods_flutter/l10n/gen/ods_localizations.dart';
 
-class OdsCircularProgressIndicator extends StatefulWidget {
+class OdsCircularProgressIndicator extends StatelessWidget {
   /// ODS CircularProgressIndicator.
   const OdsCircularProgressIndicator({
     Key? key,
@@ -29,20 +29,8 @@ class OdsCircularProgressIndicator extends StatefulWidget {
   final String? label;
 
   @override
-  State<OdsCircularProgressIndicator> createState() =>
-      _OdsCircularProgressIndicatorState();
-}
-
-class _OdsCircularProgressIndicatorState
-    extends State<OdsCircularProgressIndicator> {
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final progressValue = widget.progress ?? 0.0;
+    final progressValue = progress ?? 0.0;
 
     return TweenAnimationBuilder<double>(
       tween: Tween(begin: 0.0, end: progressValue),
@@ -50,7 +38,7 @@ class _OdsCircularProgressIndicatorState
       builder: (BuildContext context, double value, Widget? child) {
         final circularProgress = CircularProgressIndicator(
           semanticsLabel: OdsLocalizations.of(context)!.componentProgressTitle,
-          value: widget.progress != null ? value : null,
+          value: progress != null ? value : null,
         );
 
         return MergeSemantics(
@@ -58,11 +46,11 @@ class _OdsCircularProgressIndicatorState
             crossAxisAlignment: CrossAxisAlignment.center,
             children: <Widget>[
               circularProgress,
-              if (widget.label != null)
+              if (label != null)
                 Padding(
                   padding: const EdgeInsets.all(spacingM),
                   child: Text(
-                    widget.label!,
+                    label!,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
                 ),

--- a/library/lib/components/progress/ods_linear_progress_indicator.dart
+++ b/library/lib/components/progress/ods_linear_progress_indicator.dart
@@ -14,7 +14,7 @@ import 'package:flutter/material.dart';
 import 'package:ods_flutter/guidelines/spacings.dart';
 import 'package:ods_flutter/l10n/gen/ods_localizations.dart';
 
-class OdsLinearProgressIndicator extends StatefulWidget {
+class OdsLinearProgressIndicator extends StatelessWidget {
   /// ODS CircularProgressIndicator.
   const OdsLinearProgressIndicator({
     Key? key,
@@ -37,18 +37,6 @@ class OdsLinearProgressIndicator extends StatefulWidget {
   final bool? showCurrentValue;
 
   @override
-  State<OdsLinearProgressIndicator> createState() =>
-      _OdsLinearProgressIndicatorState();
-}
-
-class _OdsLinearProgressIndicatorState
-    extends State<OdsLinearProgressIndicator> {
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return MergeSemantics(
       child: Column(
@@ -58,14 +46,14 @@ class _OdsLinearProgressIndicatorState
             padding: const EdgeInsets.only(top: spacingS, bottom: spacingS),
             child: Row(
               children: [
-                if (widget.icon != null) ...[
-                  widget.icon!,
+                if (icon != null) ...[
+                  icon!,
                   const SizedBox(width: 8),
                 ],
-                if (widget.label != null)
+                if (label != null)
                   Flexible(
                     child: Text(
-                      widget.label!,
+                      label!,
                       style: Theme.of(context).textTheme.bodyMedium,
                     ),
                   ),
@@ -73,7 +61,7 @@ class _OdsLinearProgressIndicatorState
             ),
           ),
           TweenAnimationBuilder<double>(
-            tween: Tween(begin: 0.0, end: widget.progress ?? 0.0),
+            tween: Tween(begin: 0.0, end: progress ?? 0.0),
             duration: const Duration(seconds: 5),
             builder: (BuildContext context, double value, Widget? child) {
               final progressValue = value * 100;
@@ -84,19 +72,19 @@ class _OdsLinearProgressIndicatorState
                   LinearProgressIndicator(
                     semanticsLabel:
                         OdsLocalizations.of(context)!.componentProgressTitle,
-                    value: widget.progress != null ? value : null,
+                    value: progress != null ? value : null,
                   ),
                   ExcludeSemantics(
                     child: Padding(
                       padding: const EdgeInsets.only(
                           top: spacingS, bottom: spacingS),
-                      child: widget.showCurrentValue == true &&
-                              widget.showCurrentValue != null
-                          ? Text(
-                              "${progressValue.toInt()} %",
-                              style: Theme.of(context).textTheme.bodyMedium,
-                            )
-                          : null,
+                      child:
+                          showCurrentValue == true && showCurrentValue != null
+                              ? Text(
+                                  "${progressValue.toInt()} %",
+                                  style: Theme.of(context).textTheme.bodyMedium,
+                                )
+                              : null,
                     ),
                   ),
                 ],

--- a/library/lib/components/radio_button/ods_radio_button.dart
+++ b/library/lib/components/radio_button/ods_radio_button.dart
@@ -16,7 +16,7 @@ import 'package:flutter/material.dart';
 ///
 /// The OdsCheckbox widget represents a checkbox element that can be checked or unchecked.
 /// It allows for handling the checkbox state and triggering a callback when its state changes.
-class OdsRadioButton<T> extends StatefulWidget {
+class OdsRadioButton<T> extends StatelessWidget {
   /// Creates an ODS RadioButton.
   const OdsRadioButton({
     Key? key,
@@ -39,17 +39,12 @@ class OdsRadioButton<T> extends StatefulWidget {
   final bool? enabled;
 
   @override
-  State<OdsRadioButton<T>> createState() => _OdsRadioButtonState<T>();
-}
-
-class _OdsRadioButtonState<T> extends State<OdsRadioButton<T>> {
-  @override
   Widget build(BuildContext context) {
     return Semantics(
       child: Radio<T>(
-        value: widget.value,
-        onChanged: widget.enabled != false ? widget.onCheckedChange : null,
-        groupValue: widget.groupValue,
+        value: value,
+        onChanged: enabled != false ? onCheckedChange : null,
+        groupValue: groupValue,
       ),
     );
   }

--- a/library/lib/components/switch/ods_switch.dart
+++ b/library/lib/components/switch/ods_switch.dart
@@ -17,7 +17,7 @@ import 'package:ods_flutter/l10n/gen/ods_localizations.dart';
 /// ODS OdsSwitch.
 ///
 ///  Switch is used to toggle the on/off state of a single setting.
-class OdsSwitch extends StatefulWidget {
+class OdsSwitch extends StatelessWidget {
   /// Creates an ODS Switch .
   const OdsSwitch({
     Key? key,
@@ -40,13 +40,8 @@ class OdsSwitch extends StatefulWidget {
   final bool? enabled;
 
   @override
-  State<OdsSwitch> createState() => _OdsSwitchState();
-}
-
-class _OdsSwitchState extends State<OdsSwitch> {
-  @override
   Widget build(BuildContext context) {
-    String switchValue = widget.checked
+    String switchValue = checked
         ? OdsLocalizations.of(context)!.componentSwitchesChecked
         : OdsLocalizations.of(context)!.componentSwitchesUnchecked;
 
@@ -54,13 +49,13 @@ class _OdsSwitchState extends State<OdsSwitch> {
 
     return Semantics(
       value: switchValue,
-      enabled: widget.enabled,
+      enabled: enabled,
       button: true,
       excludeSemantics: true,
       child: Switch(
-          thumbIcon: widget.icon == true ? odsSwitchIcon.thumbIcon : null,
-          value: widget.checked,
-          onChanged: widget.enabled == true ? widget.onCheckedChange : null),
+          thumbIcon: icon == true ? odsSwitchIcon.thumbIcon : null,
+          value: checked,
+          onChanged: enabled == true ? onCheckedChange : null),
     );
   }
 }

--- a/library/lib/components/textfield/ods_text_field.dart
+++ b/library/lib/components/textfield/ods_text_field.dart
@@ -18,7 +18,7 @@ import 'package:ods_flutter/guidelines/spacings.dart';
 /// A text field lets the user enter text, either with hardware keyboard or with an onscreen keyboard.
 ///
 ///.
-class OdsTextField extends StatefulWidget {
+class OdsTextField extends StatelessWidget {
   /// A controller for an editable text field
   final TextEditingController? controller;
 
@@ -91,51 +91,41 @@ class OdsTextField extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<OdsTextField> createState() => _OdsTextFieldState();
-}
-
-class _OdsTextFieldState extends State<OdsTextField> {
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return MergeSemantics(
       child: Semantics(
         child: TextField(
-          controller: widget.controller,
-          keyboardType: widget.keyboardType,
-          textInputAction: widget.keyboardActions,
-          onChanged: widget.onValueChange,
-          textCapitalization: widget.textCapitalization == true
+          controller: controller,
+          keyboardType: keyboardType,
+          textInputAction: keyboardActions,
+          onChanged: onValueChange,
+          textCapitalization: textCapitalization == true
               ? TextCapitalization.characters
               : TextCapitalization.none,
           keyboardAppearance: Theme.of(context).brightness == Brightness.dark
               ? Brightness.dark
               : Brightness.light,
-          maxLength: widget.characterCounter,
-          enabled: widget.enabled,
-          readOnly: widget.readOnly,
-          minLines: widget.maxLines != null ? 1 : null,
-          maxLines: widget.maxLines,
+          maxLength: characterCounter,
+          enabled: enabled,
+          readOnly: readOnly,
+          minLines: maxLines != null ? 1 : null,
+          maxLines: maxLines,
           decoration: InputDecoration(
-            prefixIcon: widget.leadingIcon,
-            suffixIcon: widget.trailingText != null
+            prefixIcon: leadingIcon,
+            suffixIcon: trailingText != null
                 ? Padding(
                     padding: const EdgeInsets.fromLTRB(
                         spacingM, spacingM, spacingM, spacingM),
                     child: Text(
-                      widget.trailingText!,
+                      trailingText!,
                       style: TextStyle(
                           color: Theme.of(context).colorScheme.tertiary),
                     ),
                   )
-                : widget.trailingIcon,
-            labelText: widget.label,
-            hintText: widget.placeholder,
-            errorText: widget.errorMessage,
+                : trailingIcon,
+            labelText: label,
+            hintText: placeholder,
+            errorText: errorMessage,
             border: const OutlineInputBorder(),
             filled: false,
           ),

--- a/library/lib/components/textfield/password/ods_password_text_field.dart
+++ b/library/lib/components/textfield/password/ods_password_text_field.dart
@@ -74,11 +74,6 @@ class OdsPasswordTextField extends StatefulWidget {
 }
 
 class _OdsPasswordTextFieldState extends State<OdsPasswordTextField> {
-  @override
-  void initState() {
-    super.initState();
-  }
-
   bool isObscureText = true;
 
   @override


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

none

### Description

change StatefulWidget to Stateless when possible

### Motivation & Context

Makes the code more readable, and avoid unnecessary rebuilds

### Types of change

<!-- What types of changes does you code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Accessibility

- [ ] My change follows accessibility good practices

#### Design

- [ ] My change respects the design guidelines defined in [Orange Design System](https://system.design.orange.com/0c1af118d/p/8118d1-web)
- [ ] My change is compatible with responsive display

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] Manually test on simulators and on a physical device (Android & iOS, orientation change, dark/light mode)
- [ ] Code review
- [ ] Design review
- [ ] A11y review